### PR TITLE
Fix iq dashboard changes

### DIFF
--- a/src/components/dashboard/layout.tsx
+++ b/src/components/dashboard/layout.tsx
@@ -122,7 +122,6 @@ export const DashboardLayout = (props: DashboardLayoutProps) => {
             {...(!squeeze && pagePadding)}
             mx="auto"
             h="auto"
-            
           >
             {children}
           </chakra.div>

--- a/src/components/dashboard/layout.tsx
+++ b/src/components/dashboard/layout.tsx
@@ -99,6 +99,7 @@ export const DashboardLayout = (props: DashboardLayoutProps) => {
             transition="box-shadow 0.2s"
             backdropFilter="blur(2px)"
             bg="bodyBg"
+            zIndex="sticky"
           >
             <Navbar display={{ base: 'none', md: 'flex' }} />
             <Flex
@@ -119,9 +120,9 @@ export const DashboardLayout = (props: DashboardLayoutProps) => {
           <chakra.div
             maxW={{ xl: 'container.lg' }}
             {...(!squeeze && pagePadding)}
-            pb="20"
             mx="auto"
-            h="full"
+            h="auto"
+            
           >
             {children}
           </chakra.div>

--- a/src/pages/dashboard/bridge.tsx
+++ b/src/pages/dashboard/bridge.tsx
@@ -22,7 +22,7 @@ import { RiEditLine } from 'react-icons/ri'
 const Bridge: NextPage = () => {
   return (
     <DashboardLayout>
-      <Flex direction="column" gap="6" pt="8">
+      <Flex direction="column" gap="6" pt="8" pb="16">
         <Flex direction="column" gap="2">
           <Heading fontWeight="bold" fontSize={{ md: 'xl', lg: '2xl' }}>
             IQ Bridge

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -143,9 +143,9 @@ const Home: NextPage = () => {
       <Stack h="full" mb="4.375em" spacing={{ base: 7, md: 5, lg: 6 }} pb="8">
         <Flex
           gap={{ lg: '15' }}
-          px={{ base: 3, md: '5' }}
+          px={4}
           py={{ base: 3, md: 7, lg: '2.5' }}
-          pr={{ md: '6.25em' }}
+          pr={{ lg: '6.25em' }}
           bg="cardBg"
           border="solid 1px"
           borderColor="divider"
@@ -416,7 +416,7 @@ const Home: NextPage = () => {
                 All-time high
               </Text>
               <Text fontSize={{ base: 'md', md: '2xl' }} fontWeight="medium">
-                ${coinMarket?.ath.toFixed(6)}
+                ${coinMarket?.ath.toFixed(4)}&nbsp;
                 <chakra.sup
                   fontSize={{ base: 'xx-small', md: 'md' }}
                   color={
@@ -459,7 +459,7 @@ const Home: NextPage = () => {
                 All-time low
               </Text>
               <Text fontSize={{ base: 'md', md: '2xl' }} fontWeight="medium">
-                ${coinMarket?.atl.toFixed(6)}
+                ${coinMarket?.atl.toFixed(6)}&nbsp;
                 <chakra.sup
                   fontSize={{ base: 'xx-small', md: 'md' }}
                   color={

--- a/src/pages/dashboard/swap.tsx
+++ b/src/pages/dashboard/swap.tsx
@@ -23,6 +23,7 @@ const Swap: NextPage = () => {
         }
         px={{ base: '6', md: '7', lg: '10' }}
         py={{ base: '5', lg: '0' }}
+        pb="16"
       >
         <Box pt={8} pr={{ lg: 14 }}>
           <Heading mb={2} fontSize={{ md: 'xl', lg: '2xl' }}>

--- a/src/pages/dashboard/voting.tsx
+++ b/src/pages/dashboard/voting.tsx
@@ -69,8 +69,9 @@ const Voting: NextPage = () => {
         h="full"
         overflow="auto"
         py={{ base: '5', lg: '0' }}
+        
       >
-        <Flex pt="8" pr={{ lg: 8 }} flex="auto" direction="column" gap="8">
+        <Flex pt="8"  pr={{ lg: 8 }} flex="auto" direction="column" gap="8">
           <Flex direction="column" gap="2">
             <Heading fontWeight="bold" fontSize={{ md: 'xl', lg: '2xl' }}>
               IQ Voting
@@ -102,11 +103,12 @@ const Voting: NextPage = () => {
           borderLeftColor={{ lg: 'divider' }}
           px={{ base: '2', md: '12' }}
           pr={{ lg: 1 }}
-          h="full"
+          h={{base: "full", lg:"100vh"}}
           fontSize="sm"
           textAlign={{ base: 'center', lg: 'left' }}
           maxW={{ lg: '25.875em' }}
           minW="18.75em"
+          pb="16"
         >
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Neque, et

--- a/src/pages/dashboard/voting.tsx
+++ b/src/pages/dashboard/voting.tsx
@@ -69,9 +69,8 @@ const Voting: NextPage = () => {
         h="full"
         overflow="auto"
         py={{ base: '5', lg: '0' }}
-        
       >
-        <Flex pt="8"  pr={{ lg: 8 }} flex="auto" direction="column" gap="8">
+        <Flex pt="8" pr={{ lg: 8 }} flex="auto" direction="column" gap="8">
           <Flex direction="column" gap="2">
             <Heading fontWeight="bold" fontSize={{ md: 'xl', lg: '2xl' }}>
               IQ Voting
@@ -103,7 +102,7 @@ const Voting: NextPage = () => {
           borderLeftColor={{ lg: 'divider' }}
           px={{ base: '2', md: '12' }}
           pr={{ lg: 1 }}
-          h={{base: "full", lg:"100vh"}}
+          h={{ base: 'full', lg: '100vh' }}
           fontSize="sm"
           textAlign={{ base: 'center', lg: 'left' }}
           maxW={{ lg: '25.875em' }}

--- a/src/theme/semantic-tokens.ts
+++ b/src/theme/semantic-tokens.ts
@@ -61,7 +61,7 @@ export const semanticTokens: SemanticTokens = {
       _dark: 'gray.500',
     },
     cardBg: {
-      default: 'gray.200',
+      default: 'gray.50',
       _dark: 'gray.700',
     },
     pageBorderColor: {


### PR DESCRIPTION
# Fixes issues on IQ UI

- [x] wrong background color for the first box in light mode. It is deeper than it is supposed to be. correct color is Gray 50.
![image](https://user-images.githubusercontent.com/99387231/181385997-81e3b99d-7f87-47f8-b4ea-bbf3d6d6a0c1.png)

- [x] Add a little of space after the contents on the dashboard. part of the last box is cut away which will affect the graph too when implemented.
<img width="722" alt="image" src="https://user-images.githubusercontent.com/99387231/181386146-4b3da35c-444d-44f2-be8c-89bb65efa454.png">

- [x] Correct inconsistencies in spacing and color of the hypertext in the box beside the graph (under all-time low) for all breakpoints.
![image](https://user-images.githubusercontent.com/99387231/181387500-47331cbb-c130-47dc-8d3a-3f48858f09d0.png)

- [x] Extend text on the first box for md breakpoint. 
![image](https://user-images.githubusercontent.com/99387231/181388382-4f6ef635-5886-4be9-bc90-c695b5afd72a.png)

- [x] Add more spacing to dashboard after contents in mobile. the contents are hidden behind the nav bar.
![image](https://user-images.githubusercontent.com/99387231/181388615-09ef3ca2-8d67-4a20-9e7e-70d6dc4afa94.png)
- [x] Pages with dividers in the middle don't have the dividers extending to the end of the page.
![image](https://user-images.githubusercontent.com/99387231/181717203-aec3dc31-de5d-40aa-9e1b-dc3e2a82681e.png)
- [x] The swap page and the bridge page get cut off at the end on mobile bp
![image](https://user-images.githubusercontent.com/99387231/181718375-fb8df0fb-9008-45dd-a402-b8394a3ee080.png)
![image](https://user-images.githubusercontent.com/99387231/181718504-d4f01d32-f887-43be-841a-72727a3eeab2.png)


## Linked issues

fixes https://github.com/EveripediaNetwork/issues/issues/587
