### PR TITLE
fix (treasury): make table full width

### DIFF
--- a/src/pages/dashboard/treasury.tsx
+++ b/src/pages/dashboard/treasury.tsx
@@ -146,8 +146,6 @@ const Treasury: NextPage = () => {
           <PieChart width={200} height={200}>
             <Pie
               data={PIE_CHART_DATA}
-              // cx={200}
-              // cy={200}
               labelLine={false}
               fill="#8884d8"
               dataKey="value"

--- a/src/pages/dashboard/treasury.tsx
+++ b/src/pages/dashboard/treasury.tsx
@@ -18,6 +18,7 @@ import {
   Thead,
   Tr,
   chakra,
+  Wrap,
 } from '@chakra-ui/react'
 import { NextPage } from 'next'
 import React, { useEffect, useState } from 'react'
@@ -89,7 +90,7 @@ const Treasury: NextPage = () => {
       <Text fontWeight="bold" fontSize="2xl" mt="10">
         Tokens
       </Text>
-      <Flex direction={{ base: 'column', md: 'row' }} mt="6" gap="40px">
+      <Wrap direction={{ base: 'column', md: 'row' }} mt="6" gap="40px">
         <chakra.div overflowX="auto">
           <Table border="solid 1px" borderColor="divider">
             <Thead border="none" bg="cardBg">
@@ -130,19 +131,23 @@ const Treasury: NextPage = () => {
           </Table>
         </chakra.div>
         <chakra.div
-          w="max-content"
+          flex="auto"
+          w="max"
           mx="auto"
           sx={{
             '.pie-cell': {
               stroke: 'transparent',
             },
+            '& svg, & .recharts-wrapper': {
+              boxSize: 'full !important',
+            },
           }}
         >
-          <PieChart width={400} height={400}>
+          <PieChart width={200} height={200}>
             <Pie
               data={PIE_CHART_DATA}
-              cx={200}
-              cy={200}
+              // cx={200}
+              // cy={200}
               labelLine={false}
               fill="#8884d8"
               dataKey="value"
@@ -158,7 +163,7 @@ const Treasury: NextPage = () => {
             <Tooltip />
           </PieChart>
         </chakra.div>
-      </Flex>
+      </Wrap>
     </DashboardLayout>
   )
 }


### PR DESCRIPTION
FixesEveripediaNetwork/issues#617
<img width="1121" alt="CleanShot 2022-08-05 at 20 00 58@2x" src="https://user-images.githubusercontent.com/30869823/183143998-85224e9e-ef67-4887-95f5-7aedb88d3502.png">
<img width="797" alt="CleanShot 2022-08-05 at 20 01 06@2x" src="https://user-images.githubusercontent.com/30869823/183144012-b0cb38a9-a479-44de-bb27-b2cadb7ff080.png">
<img width="492" alt="CleanShot 2022-08-05 at 20 01 23@2x" src="https://user-images.githubusercontent.com/30869823/183144017-0e6d75bb-e799-41dd-acb3-428a78762fbe.png">

