### PR TITLE
Lock page fixes

### DIFF
--- a/src/components/cards/StakeCard.tsx
+++ b/src/components/cards/StakeCard.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text, FlexProps, } from '@chakra-ui/react'
+import { Flex, Text, FlexProps } from '@chakra-ui/react'
 import React from 'react'
 
 type StakeCardProps = {
@@ -20,8 +20,8 @@ const StakeCard = (props: StakeCardProps) => {
     >
       <Text fontSize="xs" color="grayText">
         {title}
-      </Text> 
-        <Text fontWeight="semibold">{value} </Text>
+      </Text>
+      <Text fontWeight="semibold">{value} </Text>
     </Flex>
   )
 }

--- a/src/components/cards/StakeCard.tsx
+++ b/src/components/cards/StakeCard.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text, FlexProps } from '@chakra-ui/react'
+import { Flex, Text, FlexProps, } from '@chakra-ui/react'
 import React from 'react'
 
 type StakeCardProps = {
@@ -20,8 +20,8 @@ const StakeCard = (props: StakeCardProps) => {
     >
       <Text fontSize="xs" color="grayText">
         {title}
-      </Text>
-      <Text fontWeight="semibold">{value}</Text>
+      </Text> 
+        <Text fontWeight="semibold">{value} </Text>
     </Flex>
   )
 }

--- a/src/components/dashboard/layout.tsx
+++ b/src/components/dashboard/layout.tsx
@@ -13,7 +13,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 import React, { useMemo, useState, useRef, useEffect } from 'react'
-import { useViewportScroll } from 'framer-motion'
+import { useScroll } from 'framer-motion'
 
 type DashboardLayoutProps = {
   children: React.ReactNode
@@ -25,7 +25,7 @@ export const DashboardLayout = (props: DashboardLayoutProps) => {
   const ref = useRef<HTMLDivElement | null>(null)
   const [y, setY] = useState(0)
   const height = ref.current ? ref.current.getBoundingClientRect() : 0
-  const { scrollY } = useViewportScroll()
+  const { scrollY } = useScroll()
   useEffect(() => {
     return scrollY.onChange(() => setY(scrollY.get()))
   }, [scrollY])

--- a/src/components/elements/Slider/LockSlider.tsx
+++ b/src/components/elements/Slider/LockSlider.tsx
@@ -70,6 +70,7 @@ const LockSlider = ({
           <RangeSlider
             colorScheme="pink"
             w={{ base: 170, md: 330, lg: 250 }}
+            defaultValue={[lockPeriod]}
             value={[lockPeriod]}
             onChange={value => updateLockPeriod(value[0])}
             step={1}

--- a/src/components/elements/Slider/LockSlider.tsx
+++ b/src/components/elements/Slider/LockSlider.tsx
@@ -1,0 +1,116 @@
+import React, { useState, useEffect } from 'react'
+import {
+  Flex,
+  Text,
+  RangeSlider,
+  RangeSliderTrack,
+  RangeSliderFilledTrack,
+  RangeSliderThumb,
+  InputGroup,
+  InputLeftAddon,
+  InputRightAddon,
+  Input,
+  useToast,
+} from '@chakra-ui/react'
+import { useAccount } from 'wagmi'
+import { useLockOverview } from '@/hooks/useLockOverview'
+
+const LockSlider = ({
+  updateLockend,
+}: {
+  updateLockend: (value: number) => void
+}) => {
+  const [lockPeriod, setLockPeriod] = useState(0)
+  const toast = useToast()
+  const { isConnected } = useAccount()
+  const { getMaximumLockablePeriod, lockEndDate } = useLockOverview()
+  const [remainingLockablePeriod, setRemainingLockablePeriod] = useState(208)
+
+  useEffect(() => {
+    if (lockEndDate && typeof lockEndDate !== 'number') {
+      const fetchMaxLockPeriod = async () => {
+        const maxDate = await getMaximumLockablePeriod(lockEndDate)
+        if (maxDate > 0) {
+          const weeks = Number(maxDate / 7)
+          if (weeks > 0) setRemainingLockablePeriod(Number(weeks.toFixed()))
+        } else setRemainingLockablePeriod(208)
+      }
+      fetchMaxLockPeriod()
+    } else {
+      setRemainingLockablePeriod(208)
+    }
+  }, [lockEndDate, getMaximumLockablePeriod])
+
+  const updateLockPeriod = (value: number | string) => {
+    if (!isConnected) return
+    if (value) {
+      const convertedValue = typeof value === 'string' ? parseInt(value) : value
+      if (convertedValue <= remainingLockablePeriod) {
+        setLockPeriod(convertedValue)
+        updateLockend(convertedValue * 7)
+      } else {
+        toast({
+          title: `The lock period cannot be greater than the maximum lockable period for you, which is ${remainingLockablePeriod} weeks`,
+          position: 'top-right',
+          isClosable: true,
+          status: 'error',
+        })
+      }
+    }
+  }
+
+  return (
+    <Flex direction="column" w="full" gap="3">
+      <Flex p="5" pr="5" rounded="lg" border="solid 1px" borderColor="divider">
+        <Flex direction="column" gap="2">
+          <Text color="grayText2" fontSize="xs">
+            Lock period (weeks)
+          </Text>
+          <RangeSlider
+            colorScheme="pink"
+            w={{ base: 170, md: 330, lg: 250 }}
+            defaultValue={[lockPeriod]}
+            value={[lockPeriod]}
+            onChange={value => updateLockPeriod(value[0])}
+            step={1}
+            max={remainingLockablePeriod}
+            isDisabled={!isConnected}
+          >
+            <RangeSliderTrack bg="divider2">
+              <RangeSliderFilledTrack />
+            </RangeSliderTrack>
+            <RangeSliderThumb index={0} />
+          </RangeSlider>
+        </Flex>
+        <Flex ml="auto" align="end">
+          <InputGroup bg="lightCard" size="xs">
+            <InputLeftAddon
+              cursor="pointer"
+              onClick={() => updateLockPeriod(lockPeriod - 1)}
+              bg="lightCard"
+            >
+              <Text>-</Text>
+            </InputLeftAddon>
+            <Input
+              value={lockPeriod}
+              w="10"
+              onChange={e => updateLockPeriod(e.target.value)}
+              disabled={!isConnected}
+              bg="lightCard"
+              textAlign="center"
+            />
+            <InputRightAddon
+              cursor="pointer"
+              onClick={() => updateLockPeriod(lockPeriod + 1)}
+              bg="lightCard"
+            >
+              <Text>+</Text>
+            </InputRightAddon>
+          </InputGroup>
+        </Flex>
+      </Flex>
+    </Flex>
+  )
+}
+
+export default LockSlider

--- a/src/components/elements/Slider/LockSlider.tsx
+++ b/src/components/elements/Slider/LockSlider.tsx
@@ -42,6 +42,7 @@ const LockSlider = ({
   }, [lockEndDate, getMaximumLockablePeriod])
 
   const updateLockPeriod = (value: number | string) => {
+    console.log(value)
     if (!isConnected) return
     if (value) {
       const convertedValue = typeof value === 'string' ? parseInt(value) : value
@@ -69,7 +70,6 @@ const LockSlider = ({
           <RangeSlider
             colorScheme="pink"
             w={{ base: 170, md: 330, lg: 250 }}
-            defaultValue={[lockPeriod]}
             value={[lockPeriod]}
             onChange={value => updateLockPeriod(value[0])}
             step={1}

--- a/src/components/elements/Slider/LockSlider.tsx
+++ b/src/components/elements/Slider/LockSlider.tsx
@@ -42,7 +42,6 @@ const LockSlider = ({
   }, [lockEndDate, getMaximumLockablePeriod])
 
   const updateLockPeriod = (value: number | string) => {
-    console.log(value)
     if (!isConnected) return
     if (value) {
       const convertedValue = typeof value === 'string' ? parseInt(value) : value
@@ -75,7 +74,6 @@ const LockSlider = ({
             onChange={value => updateLockPeriod(value[0])}
             step={1}
             max={remainingLockablePeriod}
-            isDisabled={!isConnected}
           >
             <RangeSliderTrack bg="divider2">
               <RangeSliderFilledTrack />

--- a/src/components/lock/IncreaseLockTime.tsx
+++ b/src/components/lock/IncreaseLockTime.tsx
@@ -1,0 +1,129 @@
+import { useLock } from '@/hooks/useLock'
+import React, { useState, useEffect } from 'react'
+import { useToast, IconButton } from '@chakra-ui/react'
+import { RiArrowDownLine } from 'react-icons/ri'
+import { useLockOverview } from '@/hooks/useLockOverview'
+import { useReward } from '@/hooks/useReward'
+import { useWaitForTransaction } from 'wagmi'
+import { calculateReturn } from '@/utils/LockOverviewUtils'
+import LockFormCommon from './LockFormCommon'
+import LockSlider from '../elements/Slider/LockSlider'
+
+const IncreaseLockTime = () => {
+  const { increaseLockPeriod } = useLock()
+  const [loading, setLoading] = useState(false)
+  const { userTotalIQLocked, lockEndDate } = useLockOverview()
+  const [trxHash, setTrxHash] = useState()
+  const toast = useToast()
+  const [lockend, setLockend] = useState<Date>()
+  const [lockEndMemory, setLockEndValueMemory] = useState<Date>()
+  const [receivedAmount, setReceivedAmount] = useState(0)
+  const [lockValue, setLockValue] = useState(0)
+  const { checkPoint } = useReward()
+  const { data } = useWaitForTransaction({ hash: trxHash })
+
+  const resetValues = () => {
+    setLoading(false)
+    setLockValue(0)
+    setTrxHash(undefined)
+  }
+
+  useEffect(() => {
+    if (trxHash && data) {
+      if (data.status) {
+        toast({
+          title: `IQ successfully locked`,
+          position: 'top-right',
+          isClosable: true,
+          status: 'success',
+        })
+        checkPoint()
+        resetValues()
+      } else {
+        toast({
+          title: `Transaction could not be completed`,
+          position: 'top-right',
+          isClosable: true,
+          status: 'error',
+        })
+        resetValues()
+      }
+    }
+  }, [data, toast, trxHash, checkPoint])
+
+  useEffect(() => {
+    const amountToBeRecieved = calculateReturn(
+      userTotalIQLocked,
+      lockValue,
+      lockEndDate,
+      0,
+    )
+    setReceivedAmount(amountToBeRecieved)
+  }, [userTotalIQLocked, lockValue])
+
+  useEffect(() => {
+    if (!lockend && lockEndDate && typeof lockEndDate !== 'number') {
+      setLockend(lockEndDate)
+      setLockEndValueMemory(lockEndDate)
+    }
+  }, [lockEndDate, lockend])
+
+  const updateLockend = (lockPeriodInput: number) => {
+    const temp = lockEndMemory || new Date()
+    const newDate = new Date(temp)
+    if (lockPeriodInput === 0) {
+      setLockValue(0)
+      return
+    }
+    newDate.setDate(temp.getUTCDate() + lockPeriodInput)
+    setLockend(newDate)
+    setLockValue(lockPeriodInput)
+  }
+
+  const handleExtendLockPeriod = async () => {
+    if (lockValue < 1 || !lockend || lockend <= lockEndDate) {
+      toast({
+        title: `You need to specify a new lock period and it must be more than the current unlock date`,
+        position: 'top-right',
+        isClosable: true,
+        status: 'error',
+      })
+      return
+    }
+    setLoading(true)
+    const result = await increaseLockPeriod(lockend.getTime())
+    if (!result) {
+      toast({
+        title: `Transaction failed`,
+        position: 'top-right',
+        isClosable: true,
+        status: 'error',
+      })
+      setLoading(false)
+    }
+    setTrxHash(result.hash)
+  }
+
+  return (
+    <>
+      <LockSlider updateLockend={(value: number) => updateLockend(value)} />
+      <IconButton
+        icon={<RiArrowDownLine />}
+        aria-label="Swap"
+        variant="outline"
+        w="fit-content"
+        mx="auto"
+        color="brandText"
+      />
+      <LockFormCommon
+        lockend={lockend}
+        receivedAmount={receivedAmount}
+        hasIQLocked={false}
+        isLoading={loading}
+        handleLockPeriodUpdate={handleExtendLockPeriod}
+      />
+    </>
+  )
+}
+
+export default IncreaseLockTime

--- a/src/components/lock/IncreaseLockTime.tsx
+++ b/src/components/lock/IncreaseLockTime.tsx
@@ -8,6 +8,7 @@ import { useWaitForTransaction } from 'wagmi'
 import { calculateReturn } from '@/utils/LockOverviewUtils'
 import LockFormCommon from './LockFormCommon'
 import LockSlider from '../elements/Slider/LockSlider'
+import { Dict } from '@chakra-ui/utils'
 
 const IncreaseLockTime = () => {
   const { increaseLockPeriod } = useLock()
@@ -91,17 +92,31 @@ const IncreaseLockTime = () => {
       return
     }
     setLoading(true)
-    const result = await increaseLockPeriod(lockend.getTime())
-    if (!result) {
-      toast({
-        title: `Transaction failed`,
-        position: 'top-right',
-        isClosable: true,
-        status: 'error',
-      })
-      setLoading(false)
+    try{
+      const result = await increaseLockPeriod(lockend.getTime())
+      if (!result) {
+        toast({
+          title: `Transaction failed`,
+          position: 'top-right',
+          isClosable: true,
+          status: 'error',
+        })
+        setLoading(false)
+      }
+      setTrxHash(result.hash)
     }
-    setTrxHash(result.hash)
+    catch(err){
+      const errorObject = err as Dict
+      if(errorObject?.code === "ACTION_REJECTED"){
+        toast({
+          title: `Transaction cancelled by user`,
+          position: 'top-right',
+          isClosable: true,
+          status: 'error',
+        })
+       }
+       setLoading(false)
+    }
   }
 
   return (

--- a/src/components/lock/IncreaseLockTime.tsx
+++ b/src/components/lock/IncreaseLockTime.tsx
@@ -6,9 +6,9 @@ import { useLockOverview } from '@/hooks/useLockOverview'
 import { useReward } from '@/hooks/useReward'
 import { useWaitForTransaction } from 'wagmi'
 import { calculateReturn } from '@/utils/LockOverviewUtils'
+import { Dict } from '@chakra-ui/utils'
 import LockFormCommon from './LockFormCommon'
 import LockSlider from '../elements/Slider/LockSlider'
-import { Dict } from '@chakra-ui/utils'
 
 const IncreaseLockTime = () => {
   const { increaseLockPeriod } = useLock()
@@ -92,7 +92,7 @@ const IncreaseLockTime = () => {
       return
     }
     setLoading(true)
-    try{
+    try {
       const result = await increaseLockPeriod(lockend.getTime())
       if (!result) {
         toast({
@@ -104,18 +104,17 @@ const IncreaseLockTime = () => {
         setLoading(false)
       }
       setTrxHash(result.hash)
-    }
-    catch(err){
+    } catch (err) {
       const errorObject = err as Dict
-      if(errorObject?.code === "ACTION_REJECTED"){
+      if (errorObject?.code === 'ACTION_REJECTED') {
         toast({
           title: `Transaction cancelled by user`,
           position: 'top-right',
           isClosable: true,
           status: 'error',
         })
-       }
-       setLoading(false)
+      }
+      setLoading(false)
     }
   }
 

--- a/src/components/lock/LockFormCommon.tsx
+++ b/src/components/lock/LockFormCommon.tsx
@@ -1,96 +1,30 @@
-import React, { useState, useEffect } from 'react'
-import {
-  Button,
-  Flex,
-  Icon,
-  Text,
-  RangeSlider,
-  RangeSliderTrack,
-  RangeSliderFilledTrack,
-  RangeSliderThumb,
-  InputGroup,
-  InputLeftAddon,
-  InputRightAddon,
-  Input,
-  useToast,
-} from '@chakra-ui/react'
-import * as Humanize from 'humanize-plus'
+import React from 'react'
+import { Button, Flex, Icon, Text, useToast } from '@chakra-ui/react'
 import { RiQuestionLine } from 'react-icons/ri'
 import { useLockOverview } from '@/hooks/useLockOverview'
 import { useNetwork, useAccount } from 'wagmi'
 import config from '@/config'
+import ReceivedInfo from './ReceivedInfo'
 
 const LockFormCommon = ({
-  hasNewLockDate,
-  lockAmount,
+  hasIQLocked,
   handleLockOrIncreaseAmount,
   handleLockPeriodUpdate,
   isLoading,
-  hasSlider,
+  lockend,
+  receivedAmount,
 }: {
-  hasNewLockDate?: boolean
-  lockAmount?: number
-  handleLockOrIncreaseAmount?: (calculatedLockPeriod?: number) => void
-  handleLockPeriodUpdate?: (newUnlockDate: Date) => void
+  hasIQLocked?: boolean
+  handleLockOrIncreaseAmount?: () => void
+  handleLockPeriodUpdate?: () => void
   isLoading: boolean
-  hasSlider: boolean
+  lockend: Date | undefined
+  receivedAmount: number
 }) => {
-  const [lockPeriod, setLockPeriod] = useState(0)
-  const { lockEndDate, getMaximumLockablePeriod } = useLockOverview()
-  const [lockend, setLockend] = useState<Date>()
-  const [lockValue, setLockValue] = useState(0)
-  const [lockEndMemory, setLockEndValueMemory] = useState<Date>()
-  const [remainingLockablePeriod, setRemainingLockablePeriod] = useState(208)
+  const { lockEndDate } = useLockOverview()
   const toast = useToast()
   const { chain } = useNetwork()
   const { isConnected } = useAccount()
-
-  const updateLockend = (lockPeriodInput: number) => {
-    const temp = lockEndMemory || new Date()
-    const newDate = new Date(temp)
-    if (lockPeriodInput === 0) {
-      setLockValue(0)
-      return
-    }
-    newDate.setDate(temp.getUTCDate() + lockPeriodInput)
-    setLockend(newDate)
-    setLockValue(lockPeriodInput)
-  }
-
-  useEffect(() => {
-    if (hasNewLockDate && lockEndDate && typeof lockEndDate !== 'number') {
-      const fetchMaxLockPeriod = async () => {
-        const maxDate = await getMaximumLockablePeriod(lockEndDate)
-        if (maxDate > 0) {
-          const weeks = Number(maxDate / 7)
-          if (weeks > 0) setRemainingLockablePeriod(Number(weeks.toFixed()))
-        } else setRemainingLockablePeriod(208)
-      }
-      fetchMaxLockPeriod()
-    }
-    if (!lockend && lockEndDate && typeof lockEndDate !== 'number') {
-      setLockend(lockEndDate)
-      setLockEndValueMemory(lockEndDate)
-    }
-  }, [lockEndDate, hasNewLockDate, getMaximumLockablePeriod, lockend])
-
-  const updateLockPeriod = (value: number | string) => {
-    if (!isConnected) return
-    if (value) {
-      const convertedValue = typeof value === 'string' ? parseInt(value) : value
-      if (convertedValue <= remainingLockablePeriod) {
-        setLockPeriod(convertedValue)
-        updateLockend(convertedValue * 7)
-      } else {
-        toast({
-          title: `The lock period cannot be greater than the maximum lockable period for you, which is ${remainingLockablePeriod} weeks`,
-          position: 'top-right',
-          isClosable: true,
-          status: 'error',
-        })
-      }
-    }
-  }
 
   const handleLockButton = () => {
     if (!isConnected || chain?.id !== parseInt(config.chainId)) {
@@ -103,85 +37,19 @@ const LockFormCommon = ({
       return
     }
     if (handleLockOrIncreaseAmount) {
-      handleLockOrIncreaseAmount(lockValue)
+      handleLockOrIncreaseAmount()
     }
 
     if (handleLockPeriodUpdate) {
-      if (lockValue < 1 || !lockend || lockend <= lockEndDate) {
-        toast({
-          title: `You need to specify a new lock period and it must be more than the current unlock date`,
-          position: 'top-right',
-          isClosable: true,
-          status: 'error',
-        })
-        return
-      }
-      handleLockPeriodUpdate(lockend)
+      handleLockPeriodUpdate()
     }
   }
 
   return (
     <>
-      {hasSlider && (
-        <Flex direction="column" w="full" gap="3">
-          <Flex
-            p="5"
-            pr="5"
-            rounded="lg"
-            border="solid 1px"
-            borderColor="divider"
-          >
-            <Flex direction="column" gap="2">
-              <Text color="grayText2" fontSize="xs">
-                Lock period (weeks)
-              </Text>
-              <RangeSlider
-                colorScheme="pink"
-                w={{ base: 170, md: 330, lg: 250 }}
-                defaultValue={[lockPeriod]}
-                value={[lockPeriod]}
-                onChange={value => updateLockPeriod(value[0])}
-                step={1}
-                max={remainingLockablePeriod}
-                isDisabled={!isConnected}
-              >
-                <RangeSliderTrack bg="divider2">
-                  <RangeSliderFilledTrack />
-                </RangeSliderTrack>
-                <RangeSliderThumb index={0} />
-              </RangeSlider>
-            </Flex>
-            <Flex ml="auto" align="end">
-              <InputGroup bg="lightCard" size="xs">
-                <InputLeftAddon
-                  cursor="pointer"
-                  onClick={() => updateLockPeriod(lockPeriod - 1)}
-                  bg="lightCard"
-                >
-                  <Text>-</Text>
-                </InputLeftAddon>
-                <Input
-                  value={lockPeriod}
-                  w="10"
-                  onChange={e => updateLockPeriod(e.target.value)}
-                  disabled={!isConnected}
-                  bg="lightCard"
-                  textAlign="center"
-                />
-                <InputRightAddon
-                  cursor="pointer"
-                  onClick={() => updateLockPeriod(lockPeriod + 1)}
-                  bg="lightCard"
-                >
-                  <Text>+</Text>
-                </InputRightAddon>
-              </InputGroup>
-            </Flex>
-          </Flex>
-        </Flex>
-      )}
+      <ReceivedInfo receivedAmount={receivedAmount} />
       <Flex w="full" direction="column" gap="4" fontSize="xs">
-        {lockend && (
+        {!hasIQLocked && lockend && (
           <Flex rounded="md" align="center" bg="lightCard" p={2}>
             <Text>New lock date </Text>
             <Text fontWeight="semibold" color="brandText" ml="auto">
@@ -189,19 +57,7 @@ const LockFormCommon = ({
             </Text>
           </Flex>
         )}
-        {lockAmount ? (
-          <Flex rounded="md" align="center" bg="lightCard" p={2}>
-            <Text>New HiIQ balance </Text>
-            <Text fontWeight="semibold" color="brandText" ml="auto">
-              {Humanize.formatNumber(
-                lockAmount + (lockAmount * 3 * lockValue) / 1460,
-                2,
-              )}
-              HiIQ
-            </Text>
-          </Flex>
-        ) : null}
-        {hasNewLockDate && typeof lockEndDate !== 'number' && (
+        {hasIQLocked && typeof lockEndDate !== 'number' && (
           <Flex align="center" w="full">
             <Icon color="brandText" as={RiQuestionLine} mr={1} />
             <Text color="brandText" fontSize={{ base: 'xx-small', md: 'xs' }}>

--- a/src/components/lock/LockOverview.tsx
+++ b/src/components/lock/LockOverview.tsx
@@ -1,14 +1,18 @@
 import { useLockOverview } from '@/hooks/useLockOverview'
-import { SimpleGrid } from '@chakra-ui/layout'
+import { SimpleGrid} from '@chakra-ui/layout'
 import React from 'react'
 import * as Humanize from 'humanize-plus'
 import { calculate4YearsYield, calculateAPR } from '@/utils/LockOverviewUtils'
 import { useErc20 } from '@/hooks/useErc20'
 import StakeCard from '../cards/StakeCard'
+import { useStatsData } from '@/utils/use-stats-data'
+import { Spinner, } from '@chakra-ui/react'
+
 
 const LockOverview = () => {
   const { totalHiiqSupply, userTotalIQLocked } = useLockOverview()
   const { tvl } = useErc20()
+  const { data } = useStatsData()
 
   const bStyles = {
     borderLeft: 'solid 1px',
@@ -28,8 +32,10 @@ const LockOverview = () => {
       bg="lightCard"
     >
       <StakeCard
-        title="Total supply of HiIQ"
-        value={`${Humanize.formatNumber(totalHiiqSupply, 2)} HIIQ`}
+        title="Number of holders"
+        value={`${data.hiiq?.holders ? data.hiiq?.holders: <Spinner variant="primary" role="status" size="sm">
+        <span>Loading...</span>
+      </Spinner> }`}
       />
       <StakeCard
         title="Total value locked"

--- a/src/components/lock/LockOverview.tsx
+++ b/src/components/lock/LockOverview.tsx
@@ -1,18 +1,26 @@
 import { useLockOverview } from '@/hooks/useLockOverview'
 import { SimpleGrid } from '@chakra-ui/layout'
-import React from 'react'
+import React, {useState, useEffect} from 'react'
 import * as Humanize from 'humanize-plus'
-import { calculate4YearsYield, calculateAPR } from '@/utils/LockOverviewUtils'
+import { calculate4YearsYield, calculateAPR, getNumberOfHiIQHolders } from '@/utils/LockOverviewUtils'
 import { useErc20 } from '@/hooks/useErc20'
-import { useStatsData } from '@/utils/use-stats-data'
 import { Spinner } from '@chakra-ui/react'
 import StakeCard from '../cards/StakeCard'
 
 const LockOverview = () => {
   const { totalHiiqSupply, userTotalIQLocked } = useLockOverview()
   const { tvl } = useErc20()
-  const { data } = useStatsData()
+  const [holders, setHolders] = useState(0)
 
+  useEffect(() => {
+    const  getHiIQHolders = async () => {
+        const data = await getNumberOfHiIQHolders()
+        setHolders(data)
+    }
+    if(!holders){
+        getHiIQHolders()
+    }
+  }, [holders])
   const bStyles = {
     borderLeft: 'solid 1px',
     borderColor: 'divider2',
@@ -32,15 +40,7 @@ const LockOverview = () => {
     >
       <StakeCard
         title="Number of holders"
-        value={`${
-          data.hiiq?.holders ? (
-            `${data.hiiq?.holders} Holders`
-          ) : (
-            <Spinner variant="primary" role="status" size="sm">
-              <span>Loading...</span>
-            </Spinner>
-          )
-        }`}
+        value={`${holders} Holders`}
       />
       <StakeCard
         title="Total value locked"

--- a/src/components/lock/LockOverview.tsx
+++ b/src/components/lock/LockOverview.tsx
@@ -4,9 +4,9 @@ import React from 'react'
 import * as Humanize from 'humanize-plus'
 import { calculate4YearsYield, calculateAPR } from '@/utils/LockOverviewUtils'
 import { useErc20 } from '@/hooks/useErc20'
-import StakeCard from '../cards/StakeCard'
 import { useStatsData } from '@/utils/use-stats-data'
 import { Spinner } from '@chakra-ui/react'
+import StakeCard from '../cards/StakeCard'
 
 const LockOverview = () => {
   const { totalHiiqSupply, userTotalIQLocked } = useLockOverview()

--- a/src/components/lock/LockOverview.tsx
+++ b/src/components/lock/LockOverview.tsx
@@ -1,10 +1,13 @@
 import { useLockOverview } from '@/hooks/useLockOverview'
 import { SimpleGrid } from '@chakra-ui/layout'
-import React, {useState, useEffect} from 'react'
+import React, { useState, useEffect } from 'react'
 import * as Humanize from 'humanize-plus'
-import { calculate4YearsYield, calculateAPR, getNumberOfHiIQHolders } from '@/utils/LockOverviewUtils'
+import {
+  calculate4YearsYield,
+  calculateAPR,
+  getNumberOfHiIQHolders,
+} from '@/utils/LockOverviewUtils'
 import { useErc20 } from '@/hooks/useErc20'
-import { Spinner } from '@chakra-ui/react'
 import StakeCard from '../cards/StakeCard'
 
 const LockOverview = () => {
@@ -13,12 +16,12 @@ const LockOverview = () => {
   const [holders, setHolders] = useState(0)
 
   useEffect(() => {
-    const  getHiIQHolders = async () => {
-        const data = await getNumberOfHiIQHolders()
-        setHolders(data)
+    const getHiIQHolders = async () => {
+      const data = await getNumberOfHiIQHolders()
+      setHolders(data)
     }
-    if(!holders){
-        getHiIQHolders()
+    if (!holders) {
+      getHiIQHolders()
     }
   }, [holders])
   const bStyles = {
@@ -38,10 +41,7 @@ const LockOverview = () => {
       rounded="lg"
       bg="lightCard"
     >
-      <StakeCard
-        title="Number of holders"
-        value={`${holders} Holders`}
-      />
+      <StakeCard title="Number of holders" value={`${holders} Holders`} />
       <StakeCard
         title="Total value locked"
         value={`${Humanize.formatNumber(tvl, 2)} IQ`}

--- a/src/components/lock/LockOverview.tsx
+++ b/src/components/lock/LockOverview.tsx
@@ -1,13 +1,12 @@
 import { useLockOverview } from '@/hooks/useLockOverview'
-import { SimpleGrid} from '@chakra-ui/layout'
+import { SimpleGrid } from '@chakra-ui/layout'
 import React from 'react'
 import * as Humanize from 'humanize-plus'
 import { calculate4YearsYield, calculateAPR } from '@/utils/LockOverviewUtils'
 import { useErc20 } from '@/hooks/useErc20'
 import StakeCard from '../cards/StakeCard'
 import { useStatsData } from '@/utils/use-stats-data'
-import { Spinner, } from '@chakra-ui/react'
-
+import { Spinner } from '@chakra-ui/react'
 
 const LockOverview = () => {
   const { totalHiiqSupply, userTotalIQLocked } = useLockOverview()
@@ -33,9 +32,15 @@ const LockOverview = () => {
     >
       <StakeCard
         title="Number of holders"
-        value={`${data.hiiq?.holders ? data.hiiq?.holders: <Spinner variant="primary" role="status" size="sm">
-        <span>Loading...</span>
-      </Spinner> }`}
+        value={`${
+          data.hiiq?.holders ? (
+            `${data.hiiq?.holders} Holders`
+          ) : (
+            <Spinner variant="primary" role="status" size="sm">
+              <span>Loading...</span>
+            </Spinner>
+          )
+        }`}
       />
       <StakeCard
         title="Total value locked"

--- a/src/components/lock/LockOverview.tsx
+++ b/src/components/lock/LockOverview.tsx
@@ -3,12 +3,12 @@ import { SimpleGrid } from '@chakra-ui/layout'
 import React from 'react'
 import * as Humanize from 'humanize-plus'
 import { calculate4YearsYield, calculateAPR } from '@/utils/LockOverviewUtils'
-import StakeCard from '../cards/StakeCard'
 import { useErc20 } from '@/hooks/useErc20'
+import StakeCard from '../cards/StakeCard'
 
 const LockOverview = () => {
   const { totalHiiqSupply, userTotalIQLocked } = useLockOverview()
-  const {tvl} = useErc20()
+  const { tvl } = useErc20()
 
   const bStyles = {
     borderLeft: 'solid 1px',

--- a/src/components/lock/LockOverview.tsx
+++ b/src/components/lock/LockOverview.tsx
@@ -4,9 +4,11 @@ import React from 'react'
 import * as Humanize from 'humanize-plus'
 import { calculate4YearsYield, calculateAPR } from '@/utils/LockOverviewUtils'
 import StakeCard from '../cards/StakeCard'
+import { useErc20 } from '@/hooks/useErc20'
 
 const LockOverview = () => {
   const { totalHiiqSupply, userTotalIQLocked } = useLockOverview()
+  const {tvl} = useErc20()
 
   const bStyles = {
     borderLeft: 'solid 1px',
@@ -31,7 +33,7 @@ const LockOverview = () => {
       />
       <StakeCard
         title="Total value locked"
-        value={`${Humanize.formatNumber(userTotalIQLocked, 2)} IQ`}
+        value={`${Humanize.formatNumber(tvl, 2)} IQ`}
         {...bStyles}
       />
       <StakeCard

--- a/src/components/lock/LockedDetails.tsx
+++ b/src/components/lock/LockedDetails.tsx
@@ -21,6 +21,7 @@ import { useLockOverview } from '@/hooks/useLockOverview'
 import * as Humanize from 'humanize-plus'
 import { useReward } from '@/hooks/useReward'
 import { useAccount, useWaitForTransaction } from 'wagmi'
+import { getDollarValue } from '@/utils/LockOverviewUtils'
 
 const LockedDetails = ({
   setOpenUnlockNotification,
@@ -43,6 +44,7 @@ const LockedDetails = ({
   const [reward, setReward] = useState(0)
   const [isExpired, setIsExpired] = useState(false)
   const [daysDiff, setDaysDiff] = useState(0)
+  const [totalIQReward, setTotalIQReward] = useState(0)
   const [userIsInitialized, setUserIsInitialized] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [isRewardClaimingLoading, setIsRewardClaimingLoading] = useState(false)
@@ -56,7 +58,9 @@ const LockedDetails = ({
       const initializationCheck = await checkIfUserIsInitialized()
       setUserIsInitialized(initializationCheck)
       const resolvedReward = await rewardEarned()
-      setReward(resolvedReward)
+      const rate = await getDollarValue()
+      setTotalIQReward(resolvedReward)
+      setReward(resolvedReward * rate)
     }
     if (totalRewardEarned && isConnected) {
       resolveReward()
@@ -170,6 +174,9 @@ const LockedDetails = ({
           Claimable Reward
         </Text>
         <Text fontSize="lg" fontWeight="bold">
+          {totalIQReward > 0 ? `${Humanize.formatNumber(totalIQReward, 2)} ` : '-'}
+        </Text>
+        <Text fontSize="xs">
           {reward > 0 ? `${Humanize.formatNumber(reward, 5)} $` : '-'}
         </Text>
       </VStack>

--- a/src/components/lock/LockedDetails.tsx
+++ b/src/components/lock/LockedDetails.tsx
@@ -141,21 +141,20 @@ const LockedDetails = ({
           display={{ base: 'none', lg: 'inherit' }}
         />
       </VStack>
-
-      <VStack align="center">
-        <Text color="grayText2" fontSize="md">
-          IQ Locked
-        </Text>
-        <Text fontSize="lg" fontWeight="bold">
-          {Humanize.formatNumber(userTotalIQLocked, 2)} IQ
-        </Text>
-      </VStack>
       <VStack align="center">
         <Text color="grayText2" fontSize="md">
           HiIQ Balance
         </Text>
         <Text fontSize="lg" fontWeight="bold">
           {Humanize.formatNumber(hiiqBalance, 2)} HiIQ
+        </Text>
+      </VStack>
+      <VStack align="center">
+        <Text color="grayText2" fontSize="md">
+          IQ Locked
+        </Text>
+        <Text fontSize="lg" fontWeight="bold">
+          {Humanize.formatNumber(userTotalIQLocked, 2)} IQ
         </Text>
       </VStack>
       <VStack align="center">

--- a/src/components/lock/LockedDetails.tsx
+++ b/src/components/lock/LockedDetails.tsx
@@ -10,6 +10,7 @@ import {
   VStack,
   Tooltip,
   useToast,
+  chakra,
 } from '@chakra-ui/react'
 import {
   RiCalculatorFill,
@@ -177,9 +178,11 @@ const LockedDetails = ({
           {totalIQReward > 0
             ? `${Humanize.formatNumber(totalIQReward, 2)} `
             : '-'}
-        </Text>
-        <Text fontSize="xs">
-          {reward > 0 ? `${Humanize.formatNumber(reward, 5)} $` : '-'}
+          {reward ? (
+            <chakra.span color="grayText2" fontWeight="light" fontSize="sm">
+              ( {Humanize.formatNumber(reward, 3)} $ )
+            </chakra.span>
+          ) : null}
         </Text>
       </VStack>
       <VStack rowGap={2}>

--- a/src/components/lock/LockedDetails.tsx
+++ b/src/components/lock/LockedDetails.tsx
@@ -174,7 +174,9 @@ const LockedDetails = ({
           Claimable Reward
         </Text>
         <Text fontSize="lg" fontWeight="bold">
-          {totalIQReward > 0 ? `${Humanize.formatNumber(totalIQReward, 2)} ` : '-'}
+          {totalIQReward > 0
+            ? `${Humanize.formatNumber(totalIQReward, 2)} `
+            : '-'}
         </Text>
         <Text fontSize="xs">
           {reward > 0 ? `${Humanize.formatNumber(reward, 5)} $` : '-'}

--- a/src/components/lock/LockedDetails.tsx
+++ b/src/components/lock/LockedDetails.tsx
@@ -68,7 +68,7 @@ const LockedDetails = ({
   }, [totalRewardEarned, checkIfUserIsInitialized, isConnected, rewardEarned])
 
   useEffect(() => {
-    if (lockEndDate && typeof lockEndDate !== 'number') {
+    if (lockEndDate && typeof lockEndDate !== 'number' && !daysDiff) {
       const currentDateTime = new Date().getTime()
       const lockedTime = lockEndDate.getTime()
 
@@ -79,7 +79,7 @@ const LockedDetails = ({
       if (differenceInDays > 0) setDaysDiff(differenceInDays)
       else setDaysDiff(0)
     }
-  }, [lockEndDate, daysDiff])
+  }, [lockEndDate])
 
   const resetValues = () => {
     setIsLoading(false)

--- a/src/components/lock/ReceivedInfo.tsx
+++ b/src/components/lock/ReceivedInfo.tsx
@@ -1,0 +1,41 @@
+import React, { useState, useEffect } from 'react'
+import { Flex, Text } from '@chakra-ui/react'
+import { BraindaoLogo3 } from '@/components/braindao-logo-3'
+import { formatValue, getDollarValue } from '@/utils/LockOverviewUtils'
+
+const ReceivedInfo = ({ receivedAmount }: { receivedAmount: number }) => {
+  const [exchangeRate, setExchangeRate] = useState(0)
+  useEffect(() => {
+    const getExchangeRate = async () => {
+      const rate = await getDollarValue()
+      setExchangeRate(rate)
+    }
+    if (!exchangeRate) {
+      getExchangeRate()
+    }
+  }, [exchangeRate])
+
+  return (
+    <Flex direction="column" w="full" gap="3">
+      <Flex p="3" pr="5" rounded="lg" border="solid 1px" borderColor="divider">
+        <Flex direction="column" gap="1.5">
+          <Text color="grayText2" fontSize="xs">
+            Recieve:
+          </Text>
+          <Flex gap="1" align="center">
+            <Text fontWeight="semibold">{formatValue(receivedAmount)}</Text>
+            <Text color="grayText2" fontSize="xs">
+              (~${formatValue(receivedAmount * exchangeRate)})
+            </Text>
+          </Flex>
+        </Flex>
+        <Flex ml="auto" align="end" gap="1">
+          <BraindaoLogo3 w="6" h="5" />
+          <Text fontWeight="medium">HiIQ</Text>
+        </Flex>
+      </Flex>
+    </Flex>
+  )
+}
+
+export default ReceivedInfo

--- a/src/components/lock/StakeIQ.tsx
+++ b/src/components/lock/StakeIQ.tsx
@@ -18,6 +18,7 @@ import { useLockOverview } from '@/hooks/useLockOverview'
 import { useReward } from '@/hooks/useReward'
 import LockFormCommon from './LockFormCommon'
 import LockSlider from '../elements/Slider/LockSlider'
+import { Dict } from '@chakra-ui/utils'
 
 const StakeIQ = ({ exchangeRate }: { exchangeRate: number }) => {
   const [lockEndMemory, setLockEndValueMemory] = useState<Date>()
@@ -122,7 +123,8 @@ const StakeIQ = ({ exchangeRate }: { exchangeRate: number }) => {
     }
     if (userTotalIQLocked > 0) {
       setLoading(true)
-      const result = await increaseLockAmount(iqToBeLocked)
+      try{
+        const result = await increaseLockAmount(iqToBeLocked)
       if (!result) {
         toast({
           title: `Transaction failed`,
@@ -133,20 +135,47 @@ const StakeIQ = ({ exchangeRate }: { exchangeRate: number }) => {
         setLoading(false)
       }
       setTrxHash(result.hash)
-    } else {
-      setLoading(true)
-      if (lockValue && typeof lockValue === 'number') {
-        const result = await lockIQ(iqToBeLocked, lockValue)
-        if (!result) {
+      }
+      catch(err){
+        const errorObject = err as Dict
+         if(errorObject?.code === "ACTION_REJECTED"){
           toast({
-            title: `Transaction failed`,
+            title: `Transaction cancelled by user`,
             position: 'top-right',
             isClosable: true,
             status: 'error',
           })
-          setLoading(false)
+         }
+         setLoading(false)
+      }
+    } else {
+      setLoading(true)
+      if (lockValue && typeof lockValue === 'number') {
+        try{
+          const result = await lockIQ(iqToBeLocked, lockValue)
+          if (!result) {
+            toast({
+              title: `Transaction failed`,
+              position: 'top-right',
+              isClosable: true,
+              status: 'error',
+            })
+            setLoading(false)
+          }
+          setTrxHash(result.hash)
         }
-        setTrxHash(result.hash)
+        catch(err){
+          const errorObject = err as Dict
+          if(errorObject?.code === "ACTION_REJECTED"){
+            toast({
+              title: `Transaction cancelled by user`,
+              position: 'top-right',
+              isClosable: true,
+              status: 'error',
+            })
+           }
+           setLoading(false)
+        }
       } else {
         toast({
           title: `You need to provide a lock period`,

--- a/src/components/lock/StakeIQ.tsx
+++ b/src/components/lock/StakeIQ.tsx
@@ -16,9 +16,9 @@ import { useLock } from '@/hooks/useLock'
 import { useAccount, useWaitForTransaction } from 'wagmi'
 import { useLockOverview } from '@/hooks/useLockOverview'
 import { useReward } from '@/hooks/useReward'
+import { Dict } from '@chakra-ui/utils'
 import LockFormCommon from './LockFormCommon'
 import LockSlider from '../elements/Slider/LockSlider'
-import { Dict } from '@chakra-ui/utils'
 
 const StakeIQ = ({ exchangeRate }: { exchangeRate: number }) => {
   const [lockEndMemory, setLockEndValueMemory] = useState<Date>()
@@ -123,35 +123,34 @@ const StakeIQ = ({ exchangeRate }: { exchangeRate: number }) => {
     }
     if (userTotalIQLocked > 0) {
       setLoading(true)
-      try{
+      try {
         const result = await increaseLockAmount(iqToBeLocked)
-      if (!result) {
-        toast({
-          title: `Transaction failed`,
-          position: 'top-right',
-          isClosable: true,
-          status: 'error',
-        })
-        setLoading(false)
-      }
-      setTrxHash(result.hash)
-      }
-      catch(err){
+        if (!result) {
+          toast({
+            title: `Transaction failed`,
+            position: 'top-right',
+            isClosable: true,
+            status: 'error',
+          })
+          setLoading(false)
+        }
+        setTrxHash(result.hash)
+      } catch (err) {
         const errorObject = err as Dict
-         if(errorObject?.code === "ACTION_REJECTED"){
+        if (errorObject?.code === 'ACTION_REJECTED') {
           toast({
             title: `Transaction cancelled by user`,
             position: 'top-right',
             isClosable: true,
             status: 'error',
           })
-         }
-         setLoading(false)
+        }
+        setLoading(false)
       }
     } else {
       setLoading(true)
       if (lockValue && typeof lockValue === 'number') {
-        try{
+        try {
           const result = await lockIQ(iqToBeLocked, lockValue)
           if (!result) {
             toast({
@@ -163,18 +162,17 @@ const StakeIQ = ({ exchangeRate }: { exchangeRate: number }) => {
             setLoading(false)
           }
           setTrxHash(result.hash)
-        }
-        catch(err){
+        } catch (err) {
           const errorObject = err as Dict
-          if(errorObject?.code === "ACTION_REJECTED"){
+          if (errorObject?.code === 'ACTION_REJECTED') {
             toast({
               title: `Transaction cancelled by user`,
               position: 'top-right',
               isClosable: true,
               status: 'error',
             })
-           }
-           setLoading(false)
+          }
+          setLoading(false)
         }
       } else {
         toast({

--- a/src/data/LockConstants.tsx
+++ b/src/data/LockConstants.tsx
@@ -3,6 +3,5 @@ export const TOTAL_REWARDS_ACROSS_LOCK_PERIOD = 1000000 * 365
 export const GAS_LIMIT = 8e6
 export const EP_COINGECKO_URL =
   'https://api.coingecko.com/api/v3/simple/price?ids=everipedia&vs_currencies=usd'
-export const IQ_TOKEN_HOLDER = 'https://ethplorer.io/service/service.php?data=0x1bf5457ecaa14ff63cc89efd560e251e814e16ba&page=pageSize%3D600%26pageTab%3Dholders%26tab%3Dtab-holders&showTx=all'
-
-
+export const IQ_TOKEN_HOLDER =
+  'https://ethplorer.io/service/service.php?data=0x1bf5457ecaa14ff63cc89efd560e251e814e16ba&page=pageSize%3D600%26pageTab%3Dholders%26tab%3Dtab-holders&showTx=all'

--- a/src/data/LockConstants.tsx
+++ b/src/data/LockConstants.tsx
@@ -3,3 +3,6 @@ export const TOTAL_REWARDS_ACROSS_LOCK_PERIOD = 1000000 * 365
 export const GAS_LIMIT = 8e6
 export const EP_COINGECKO_URL =
   'https://api.coingecko.com/api/v3/simple/price?ids=everipedia&vs_currencies=usd'
+export const IQ_TOKEN_HOLDER = 'https://ethplorer.io/service/service.php?data=0x1bf5457ecaa14ff63cc89efd560e251e814e16ba&page=pageSize%3D600%26pageTab%3Dholders%26tab%3Dtab-holders&showTx=all'
+
+

--- a/src/hooks/useErc20.ts
+++ b/src/hooks/useErc20.ts
@@ -19,6 +19,13 @@ export const useErc20 = () => {
     watch: true,
   })
 
+  const { data: totalValueLocked } = useContractRead({
+    ...readContract,
+    functionName: 'balanceOf(address)',
+    args: [config.hiiqAddress],
+    watch: true,
+  })
+
   const getUserBalance = () => {
     if (erc20Balance) {
       const result = formatContractResult(erc20Balance)
@@ -27,7 +34,16 @@ export const useErc20 = () => {
     return 0
   }
 
+  const tvl = () => {
+    if (totalValueLocked) {
+      const result = formatContractResult(totalValueLocked)
+      return result
+    }
+    return 0
+  }
+
   return {
     userTokenBalance: getUserBalance(),
+    tvl: tvl(),
   }
 }

--- a/src/hooks/useLockOverview.ts
+++ b/src/hooks/useLockOverview.ts
@@ -27,7 +27,7 @@ export const useLockOverview = () => {
 
   const { data: hiiQBalance } = useContractRead({
     ...readContract,
-    functionName: 'balanceOf',
+    functionName: 'balanceOf(address)',
     args: [address],
     overrides: { gasLimit: GAS_LIMIT },
   })
@@ -66,7 +66,7 @@ export const useLockOverview = () => {
 
   const getUserHiiqBalance = () => {
     if (hiiQBalance) {
-      return formatContractResult(hiiQBalance.amount)
+      return formatContractResult(hiiQBalance)
     }
     return 0
   }

--- a/src/hooks/useReward.ts
+++ b/src/hooks/useReward.ts
@@ -1,6 +1,6 @@
 import config from '@/config'
 import { hiIQRewardABI } from '@/config/abis'
-import { formatContractResult, getDollarValue } from '@/utils/LockOverviewUtils'
+import { formatContractResult } from '@/utils/LockOverviewUtils'
 import { Signer } from 'ethers'
 import { ContractInterface } from '@ethersproject/contracts'
 import { useAccount, useContractRead, useContract, useSigner } from 'wagmi'

--- a/src/hooks/useReward.ts
+++ b/src/hooks/useReward.ts
@@ -32,8 +32,7 @@ export const useReward = () => {
     if (totalRewardEarned) {
       const result = formatContractResult(totalRewardEarned)
       if (result > 0) {
-        const rate = await getDollarValue()
-        return rate * result
+        return result
       }
     }
     return 0

--- a/src/utils/LockOverviewUtils.ts
+++ b/src/utils/LockOverviewUtils.ts
@@ -2,6 +2,7 @@ import {
   YEARS_LOCK,
   TOTAL_REWARDS_ACROSS_LOCK_PERIOD,
   EP_COINGECKO_URL,
+  IQ_TOKEN_HOLDER,
 } from '@/data/LockConstants'
 import { Result } from '@ethersproject/abi'
 import { BigNumber, ethers } from 'ethers'
@@ -48,6 +49,16 @@ export const getDollarValue = async () => {
     const a = await fetch(EP_COINGECKO_URL)
     const price = (await a.json()).everipedia.usd
     return price
+  } catch (err) {
+    return 0
+  }
+}
+
+export const getNumberOfHiIQHolders = async () => {
+  try {
+    const response = await fetch(IQ_TOKEN_HOLDER)
+    const data = await response.json()
+    return data.pager?.holders?.total || data.token?.holdersCount || 0
   } catch (err) {
     return 0
   }

--- a/src/utils/LockOverviewUtils.ts
+++ b/src/utils/LockOverviewUtils.ts
@@ -5,6 +5,7 @@ import {
 } from '@/data/LockConstants'
 import { Result } from '@ethersproject/abi'
 import { BigNumber, ethers } from 'ethers'
+import * as Humanize from 'humanize-plus'
 
 export const calculate4YearsYield = (totalHiiq: number) => {
   let yieldWithA4YearLock = 1 * (1 + 0.75 * 4)
@@ -56,3 +57,34 @@ export const addGasLimitBuffer = (value: BigNumber) =>
   value
     .mul(ethers.BigNumber.from(10000 + 2500))
     .div(ethers.BigNumber.from(10000))
+
+export const formatValue = (value: number) => {
+  if (value !== undefined) {
+    const valueToString = value.toString()
+    return valueToString.length > 6
+      ? Humanize.compactInteger(value, 2)
+      : Humanize.formatNumber(value, 2)
+  }
+  return 0
+}
+
+export const calculateReturn = (
+  userTotalIQLocked: number,
+  lockValue: number,
+  lockEndDate: number | Date,
+  iqToBeLocked: number,
+) => {
+  let tokenToBeLocked = userTotalIQLocked
+  let timeLocked = lockValue
+  if (iqToBeLocked) {
+    tokenToBeLocked += iqToBeLocked
+  }
+  if (typeof lockEndDate !== 'number') {
+    const currentDateTime = new Date().getTime()
+    const lockedTime = lockEndDate.getTime()
+    const differenceInDays = (lockedTime - currentDateTime) / (1000 * 3600 * 24)
+    if (differenceInDays > 0) timeLocked += differenceInDays
+  }
+  const returns = tokenToBeLocked + (tokenToBeLocked * 3 * timeLocked) / 1460
+  return returns
+}


### PR DESCRIPTION
# Fixes issues with Lock page

## How should this be tested?

- [x] 1) Swap order (HiIQ balance comes first before IQ locked)
- [x] 2) Increase the Lock time tab: Show the new HiIQ balance
- [x] 3) Rework new HiIQ to be (Current HiIQ balance + new staked)
- [x] 4) Rework the right side to show the claimable IQ and its equivalent dollar value)
- [x] 5) Ensure HiIQ balance is showing
- [x] 6) Ensure Slider works correctly
- [x] 7)Remove the total supply of HiIQ because it is irrelevant  ( wait for Kesar for the replacement)
- [x] 8) Rework receive value on the stake more IQ tab to correctly show the received value
- [x] 9) Fix the wrong total value locked on stats

## Linked issues

fixes https://github.com/EveripediaNetwork/issues/issues/667