### PR TITLE
Mobile View Minor changes on IQ Dashboard

### DIFF
--- a/src/components/cards/StakeCard.tsx
+++ b/src/components/cards/StakeCard.tsx
@@ -13,8 +13,8 @@ const StakeCard = (props: StakeCardProps) => {
       direction="column"
       gap="6px"
       align="center"
-      px="10px"
-      py="7px"
+      px={{base:'8px', lg:'10px'}}
+      py={{base:'10px', lg:'7px'}}
       textAlign="center"
       {...props}
     >

--- a/src/components/cards/StakeCard.tsx
+++ b/src/components/cards/StakeCard.tsx
@@ -13,8 +13,8 @@ const StakeCard = (props: StakeCardProps) => {
       direction="column"
       gap="6px"
       align="center"
-      px={{base:'8px', lg:'10px'}}
-      py={{base:'10px', lg:'7px'}}
+      px={{ base: '8px', lg: '10px' }}
+      py={{ base: '10px', lg: '7px' }}
       textAlign="center"
       {...props}
     >

--- a/src/components/dashboard/navbar.tsx
+++ b/src/components/dashboard/navbar.tsx
@@ -61,7 +61,7 @@ export const Navbar = (props: FlexProps) => {
         align="center"
         gap="2.5"
         py="17px"
-        px={{ md: '7', lg: '4' }}
+        px={{ lg: '4' }}
         fontSize="sm"
         {...props}
       >

--- a/src/components/lock/LockOverview.tsx
+++ b/src/components/lock/LockOverview.tsx
@@ -59,7 +59,7 @@ const LockOverview = () => {
       <StakeCard
         title="Total volume locked"
         value={`${Humanize.formatNumber(tvl, 2)} IQ`}
-        {...bStyles}
+        {...{lg:bStyles}}
       />
 
       <StakeCard

--- a/src/components/lock/LockOverview.tsx
+++ b/src/components/lock/LockOverview.tsx
@@ -59,7 +59,7 @@ const LockOverview = () => {
       <StakeCard
         title="Total volume locked"
         value={`${Humanize.formatNumber(tvl, 2)} IQ`}
-        {...{lg:bStyles}}
+        {...{ lg: bStyles }}
       />
 
       <StakeCard

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -419,7 +419,7 @@ const Home: NextPage = () => {
             </Flex>
           </GridItem>
           <Flex
-            mt={{ base: '10', md: '0' }}
+            mt={{ base: '10', lg: '0' }}
             direction={{ base: 'row', lg: 'column' }}
             gap="10"
             py="12"

--- a/src/pages/dashboard/raffles/index.tsx
+++ b/src/pages/dashboard/raffles/index.tsx
@@ -30,7 +30,7 @@ const Raffles = () => {
             fontSize={{ base: 'sm', md: 'md' }}
             color="fadedText"
           >
-            Follow all the raffles made within the IQ world.
+            Get updates on all raffle results and wins.
           </Text>
         </Flex>
         <SimpleGrid

--- a/src/pages/dashboard/staking.tsx
+++ b/src/pages/dashboard/staking.tsx
@@ -196,12 +196,11 @@ const Staking: NextPage = () => {
           title="IQ Price"
           value="$0.0046"
           {...bStyles}
-          borderLeftWidth={{ base: '0', md: '1px' }}
         />
         <StakeCard
           title="Total volume locked"
           value="409,581,181 IQ"
-          {...bStyles}
+          {...{lg:bStyles}}
         />
         <StakeCard title="Estimated Holders" value="164,025" {...bStyles} />
       </SimpleGrid>

--- a/src/pages/dashboard/staking.tsx
+++ b/src/pages/dashboard/staking.tsx
@@ -192,15 +192,11 @@ const Staking: NextPage = () => {
       >
         <StakeCard title="Annual percentage rate" value="44.18%" />
 
-        <StakeCard
-          title="IQ Price"
-          value="$0.0046"
-          {...bStyles}
-        />
+        <StakeCard title="IQ Price" value="$0.0046" {...bStyles} />
         <StakeCard
           title="Total volume locked"
           value="409,581,181 IQ"
-          {...{lg:bStyles}}
+          {...{ lg: bStyles }}
         />
         <StakeCard title="Estimated Holders" value="164,025" {...bStyles} />
       </SimpleGrid>

--- a/src/pages/dashboard/stats.tsx
+++ b/src/pages/dashboard/stats.tsx
@@ -115,9 +115,14 @@ const Stats: NextPage = () => {
             Stay on top of everything happening in the IQ world.
           </Text>
         </Flex>
-        <SimpleGrid columns={{ base: 1, md: 2 }} spacingY="8" spacingX="30" pb={{base:'5rem'}}>
+        <SimpleGrid
+          columns={{ base: 1, md: 2 }}
+          spacingY="8"
+          spacingX="30"
+          pb={{ base: '5rem' }}
+        >
           {Object.entries(STATS).map(([group, val]) => (
-            <Flex direction="column" key={group} >
+            <Flex direction="column" key={group}>
               <Text color="brandText" fontSize="md" fontWeight="medium">
                 {group}
               </Text>

--- a/src/pages/dashboard/stats.tsx
+++ b/src/pages/dashboard/stats.tsx
@@ -115,9 +115,9 @@ const Stats: NextPage = () => {
             Stay on top of everything happening in the IQ world.
           </Text>
         </Flex>
-        <SimpleGrid columns={{ base: 1, md: 2 }} spacingY="6" spacingX="30">
+        <SimpleGrid columns={{ base: 1, md: 2 }} spacingY="8" spacingX="30" pb={{base:'5rem'}}>
           {Object.entries(STATS).map(([group, val]) => (
-            <Flex direction="column" key={group}>
+            <Flex direction="column" key={group} >
               <Text color="brandText" fontSize="md" fontWeight="medium">
                 {group}
               </Text>

--- a/src/pages/dashboard/voting.tsx
+++ b/src/pages/dashboard/voting.tsx
@@ -125,7 +125,7 @@ const Voting: NextPage = () => {
     const fetchSpaces = async () => {
       const myHeaders = new Headers()
       myHeaders.append('Content-Type', 'application/json')
-      const res = await fetch('https://snapshot.everipedia.com/', {
+      const res = await fetch('https://hub.snapshot.org/graphql', {
         method: 'POST',
         headers: myHeaders,
         body: graphql,
@@ -190,7 +190,6 @@ const Voting: NextPage = () => {
           pb="4.375em"
           border="solid 1px transparent"
           borderRightColor={{ lg: 'divider' }}
-          w="lg"
           py={{ base: '7', lg: '8' }}
         >
           <Flex direction="column" gap="1">
@@ -202,7 +201,7 @@ const Voting: NextPage = () => {
               color="fadedText4"
               fontWeight="medium"
             >
-              Follow the votes and stay on top of the whole IQ world.
+              Follow votes and all related information.
             </Text>
           </Flex>
           <Tabs colorScheme="brand">


### PR DESCRIPTION
# Iq dashboard responsiveness

- [x] Fix the md and mobile breakpoint for the voting page on the iq dashboard. (view correct design on figma). 
Image is not properly centered on the md bp and the mobile breakpoint and there seems to be something wrong with old votes tabs. it no longer brings out the cards from snapshot and even the empty page is not showing correctly.

- [x] Change page description for IQ voting page. Correct description on figma


- [x] Adjust the small info box on the lock and staking page in mobile breakpoint

- [x] Adjust stats page on mobile breakpoint. A part of the page has been cut off and it needs a little bit of spacing before the nav bar.

- [x] update page description for IQ raffles page

- [x] Fix extra spaces on both sides of the nav bar. Check figma for correct spacing.>

- [x] fix merged frames on dashboard for the medium breakpoint



closes https://github.com/EveripediaNetwork/issues/issues/756
