### PR TITLE
Improve staking request

### DIFF
--- a/src/components/lock/LockedDetails.tsx
+++ b/src/components/lock/LockedDetails.tsx
@@ -23,7 +23,7 @@ import * as Humanize from 'humanize-plus'
 import { useReward } from '@/hooks/useReward'
 import { useAccount, useWaitForTransaction } from 'wagmi'
 import { Dict } from '@chakra-ui/utils'
-import { useEveripediaRate } from '@/hooks/useRate'
+import { useIQRate } from '@/hooks/useRate'
 
 const LockedDetails = ({
   setOpenUnlockNotification,
@@ -52,7 +52,7 @@ const LockedDetails = ({
   const [trxHash, setTrxHash] = useState()
   const { data } = useWaitForTransaction({ hash: trxHash })
   const { isConnected } = useAccount()
-  const { rate: price } = useEveripediaRate()
+  const { rate: price } = useIQRate()
   const toast = useToast()
 
   useEffect(() => {

--- a/src/components/lock/LockedDetails.tsx
+++ b/src/components/lock/LockedDetails.tsx
@@ -24,6 +24,7 @@ import { useReward } from '@/hooks/useReward'
 import { useAccount, useWaitForTransaction } from 'wagmi'
 import { getDollarValue } from '@/utils/LockOverviewUtils'
 import { Dict } from '@chakra-ui/utils'
+import { useEveripediaRate } from '@/hooks/useRate'
 
 const LockedDetails = ({
   setOpenUnlockNotification,
@@ -52,15 +53,15 @@ const LockedDetails = ({
   const [trxHash, setTrxHash] = useState()
   const { data } = useWaitForTransaction({ hash: trxHash })
   const { isConnected } = useAccount()
+  const {rate: price} = useEveripediaRate()
   const toast = useToast()
 
   useEffect(() => {
     const resolveReward = async () => {
       const resolvedReward = await rewardEarned()
       setTotalIQReward(resolvedReward)
-      const rate = await getDollarValue()
-      if (rate > 0) {
-        setReward(resolvedReward * rate)
+      if (price > 0) {
+        setReward(resolvedReward * price)
       }
     }
     if (totalRewardEarned && isConnected) {

--- a/src/components/lock/LockedDetails.tsx
+++ b/src/components/lock/LockedDetails.tsx
@@ -22,7 +22,6 @@ import { useLockOverview } from '@/hooks/useLockOverview'
 import * as Humanize from 'humanize-plus'
 import { useReward } from '@/hooks/useReward'
 import { useAccount, useWaitForTransaction } from 'wagmi'
-import { getDollarValue } from '@/utils/LockOverviewUtils'
 import { Dict } from '@chakra-ui/utils'
 import { useEveripediaRate } from '@/hooks/useRate'
 
@@ -53,7 +52,7 @@ const LockedDetails = ({
   const [trxHash, setTrxHash] = useState()
   const { data } = useWaitForTransaction({ hash: trxHash })
   const { isConnected } = useAccount()
-  const {rate: price} = useEveripediaRate()
+  const { rate: price } = useEveripediaRate()
   const toast = useToast()
 
   useEffect(() => {

--- a/src/components/lock/ReceivedInfo.tsx
+++ b/src/components/lock/ReceivedInfo.tsx
@@ -1,11 +1,11 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import { Flex, Text } from '@chakra-ui/react'
 import { BraindaoLogo3 } from '@/components/braindao-logo-3'
-import { formatValue, getDollarValue } from '@/utils/LockOverviewUtils'
+import { formatValue } from '@/utils/LockOverviewUtils'
 import { useEveripediaRate } from '@/hooks/useRate'
 
 const ReceivedInfo = ({ receivedAmount }: { receivedAmount: number }) => {
-  const {rate: exchangeRate} = useEveripediaRate()
+  const { rate: exchangeRate } = useEveripediaRate()
   return (
     <Flex direction="column" w="full" gap="3">
       <Flex p="3" pr="5" rounded="lg" border="solid 1px" borderColor="divider">

--- a/src/components/lock/ReceivedInfo.tsx
+++ b/src/components/lock/ReceivedInfo.tsx
@@ -2,10 +2,10 @@ import React from 'react'
 import { Flex, Text } from '@chakra-ui/react'
 import { BraindaoLogo3 } from '@/components/braindao-logo-3'
 import { formatValue } from '@/utils/LockOverviewUtils'
-import { useEveripediaRate } from '@/hooks/useRate'
+import { useIQRate } from '@/hooks/useRate'
 
 const ReceivedInfo = ({ receivedAmount }: { receivedAmount: number }) => {
-  const { rate: exchangeRate } = useEveripediaRate()
+  const { rate: exchangeRate } = useIQRate()
   return (
     <Flex direction="column" w="full" gap="3">
       <Flex p="3" pr="5" rounded="lg" border="solid 1px" borderColor="divider">

--- a/src/components/lock/ReceivedInfo.tsx
+++ b/src/components/lock/ReceivedInfo.tsx
@@ -2,19 +2,10 @@ import React, { useState, useEffect } from 'react'
 import { Flex, Text } from '@chakra-ui/react'
 import { BraindaoLogo3 } from '@/components/braindao-logo-3'
 import { formatValue, getDollarValue } from '@/utils/LockOverviewUtils'
+import { useEveripediaRate } from '@/hooks/useRate'
 
 const ReceivedInfo = ({ receivedAmount }: { receivedAmount: number }) => {
-  const [exchangeRate, setExchangeRate] = useState(0)
-  useEffect(() => {
-    const getExchangeRate = async () => {
-      const rate = await getDollarValue()
-      setExchangeRate(rate)
-    }
-    if (!exchangeRate) {
-      getExchangeRate()
-    }
-  }, [exchangeRate])
-
+  const {rate: exchangeRate} = useEveripediaRate()
   return (
     <Flex direction="column" w="full" gap="3">
       <Flex p="3" pr="5" rounded="lg" border="solid 1px" borderColor="divider">

--- a/src/hooks/useErc20.ts
+++ b/src/hooks/useErc20.ts
@@ -16,6 +16,8 @@ export const useErc20 = () => {
     ...readContract,
     functionName: 'balanceOf',
     args: [address],
+    watch: true,
+     staleTime: 5000,
   })
 
   const { data: totalValueLocked } = useContractRead({

--- a/src/hooks/useErc20.ts
+++ b/src/hooks/useErc20.ts
@@ -16,7 +16,6 @@ export const useErc20 = () => {
     ...readContract,
     functionName: 'balanceOf',
     args: [address],
-    watch: true,
   })
 
   const { data: totalValueLocked } = useContractRead({

--- a/src/hooks/useErc20.ts
+++ b/src/hooks/useErc20.ts
@@ -17,7 +17,7 @@ export const useErc20 = () => {
     functionName: 'balanceOf',
     args: [address],
     watch: true,
-     staleTime: 5000,
+    staleTime: 5000,
   })
 
   const { data: totalValueLocked } = useContractRead({

--- a/src/hooks/useLockOverview.ts
+++ b/src/hooks/useLockOverview.ts
@@ -36,6 +36,8 @@ export const useLockOverview = () => {
     functionName: 'locked__end',
     args: [address],
     overrides: { gasLimit: DEFAULT_GAS_LIMIT },
+    watch: true,
+     staleTime: 5000,
   })
 
   const {
@@ -47,6 +49,8 @@ export const useLockOverview = () => {
     functionName: 'locked',
     args: [address],
     overrides: { gasLimit: DEFAULT_GAS_LIMIT },
+    watch: true,
+     staleTime: 5000,
   })
 
   const getTotalHiiqSupply = () => {

--- a/src/hooks/useLockOverview.ts
+++ b/src/hooks/useLockOverview.ts
@@ -36,7 +36,6 @@ export const useLockOverview = () => {
     functionName: 'locked__end',
     args: [address],
     overrides: { gasLimit: DEFAULT_GAS_LIMIT },
-    watch: true,
   })
 
   const {
@@ -48,7 +47,6 @@ export const useLockOverview = () => {
     functionName: 'locked',
     args: [address],
     overrides: { gasLimit: DEFAULT_GAS_LIMIT },
-    watch: true,
   })
 
   const getTotalHiiqSupply = () => {

--- a/src/hooks/useLockOverview.ts
+++ b/src/hooks/useLockOverview.ts
@@ -37,7 +37,7 @@ export const useLockOverview = () => {
     args: [address],
     overrides: { gasLimit: DEFAULT_GAS_LIMIT },
     watch: true,
-     staleTime: 5000,
+    staleTime: 5000,
   })
 
   const {
@@ -50,7 +50,7 @@ export const useLockOverview = () => {
     args: [address],
     overrides: { gasLimit: DEFAULT_GAS_LIMIT },
     watch: true,
-     staleTime: 5000,
+    staleTime: 5000,
   })
 
   const getTotalHiiqSupply = () => {

--- a/src/hooks/useRate.ts
+++ b/src/hooks/useRate.ts
@@ -1,19 +1,18 @@
-import { getDollarValue } from "@/utils/LockOverviewUtils"
-import { useEffect, useState, useRef } from "react"
+import { getDollarValue } from '@/utils/LockOverviewUtils'
+import { useEffect, useState, useRef } from 'react'
 
 export const useEveripediaRate = () => {
   const [rate, setRate] = useState(0)
   const isRendered = useRef(false)
   useEffect(() => {
-    if( !rate && !isRendered.current){
-        const fetchEveripediaRate = async () => {
-            const price = await getDollarValue()
-            setRate(price)
-            isRendered.current = true
-        }
-        fetchEveripediaRate()
+    if (!rate && !isRendered.current) {
+      const fetchEveripediaRate = async () => {
+        const price = await getDollarValue()
+        setRate(price)
+        isRendered.current = true
+      }
+      fetchEveripediaRate()
     }
   }, [])
-  
   return { rate } as const
 }

--- a/src/hooks/useRate.ts
+++ b/src/hooks/useRate.ts
@@ -1,7 +1,7 @@
 import { getDollarValue } from '@/utils/LockOverviewUtils'
 import { useEffect, useState, useRef } from 'react'
 
-export const useEveripediaRate = () => {
+export const useIQRate = () => {
   const [rate, setRate] = useState(0)
   const isRendered = useRef(false)
   useEffect(() => {

--- a/src/hooks/useRate.ts
+++ b/src/hooks/useRate.ts
@@ -1,0 +1,19 @@
+import { getDollarValue } from "@/utils/LockOverviewUtils"
+import { useEffect, useState, useRef } from "react"
+
+export const useEveripediaRate = () => {
+  const [rate, setRate] = useState(0)
+  const isRendered = useRef(false)
+  useEffect(() => {
+    if( !rate && !isRendered.current){
+        const fetchEveripediaRate = async () => {
+            const price = await getDollarValue()
+            setRate(price)
+            isRendered.current = true
+        }
+        fetchEveripediaRate()
+    }
+  }, [])
+  
+  return { rate } as const
+}

--- a/src/pages/dashboard/bridge.tsx
+++ b/src/pages/dashboard/bridge.tsx
@@ -37,7 +37,7 @@ import { EOSLogo1 } from '@/components/icons/eos-logo-1'
 import { Swap } from '@/components/icons/swap'
 import NetworkErrorNotification from '@/components/lock/NetworkErrorNotification'
 import { shortenNumber } from '@/utils/shortenNumber.util'
-import { useEveripediaRate } from '@/hooks/useRate'
+import { useIQRate } from '@/hooks/useRate'
 
 const Bridge: NextPage = () => {
   const authContext = useContext<AuthContextType>(UALContext)
@@ -56,7 +56,7 @@ const Bridge: NextPage = () => {
   const { switchNetwork, isSuccess } = useSwitchNetwork()
   const { chain } = useNetwork()
   const chainId = parseInt(config.chainId)
-  const { rate: exchangeRate } = useEveripediaRate()
+  const { rate: exchangeRate } = useIQRate()
 
   const {
     iqBalanceOnEth,

--- a/src/pages/dashboard/bridge.tsx
+++ b/src/pages/dashboard/bridge.tsx
@@ -29,7 +29,6 @@ import {
   TokenId,
   TOKENS,
 } from '@/types/bridge'
-import { getDollarValue } from '@/utils/LockOverviewUtils'
 import { IQEosLogo } from '@/components/iq-eos-logo'
 import { IQEthLogo } from '@/components/iq-eth-logo'
 import config from '@/config'
@@ -57,7 +56,7 @@ const Bridge: NextPage = () => {
   const { switchNetwork, isSuccess } = useSwitchNetwork()
   const { chain } = useNetwork()
   const chainId = parseInt(config.chainId)
-  const {rate: exchangeRate} = useEveripediaRate()
+  const { rate: exchangeRate } = useEveripediaRate()
 
   const {
     iqBalanceOnEth,

--- a/src/pages/dashboard/bridge.tsx
+++ b/src/pages/dashboard/bridge.tsx
@@ -38,6 +38,7 @@ import { EOSLogo1 } from '@/components/icons/eos-logo-1'
 import { Swap } from '@/components/icons/swap'
 import NetworkErrorNotification from '@/components/lock/NetworkErrorNotification'
 import { shortenNumber } from '@/utils/shortenNumber.util'
+import { useEveripediaRate } from '@/hooks/useRate'
 
 const Bridge: NextPage = () => {
   const authContext = useContext<AuthContextType>(UALContext)
@@ -48,7 +49,6 @@ const Bridge: NextPage = () => {
   const [inputAccount, setInputAccount] = useState<string>(
     authContext.activeUser ? authContext.activeUser.accountName : '',
   )
-  const [exchangeRate, setExchangeRate] = useState(0)
   const [openErrorNetwork, setOpenErrorNetwork] = useState(false)
   const [balances, setBalances] = useState(initialBalances)
   const [isTransferring, setIsTransferring] = useState(false)
@@ -57,6 +57,8 @@ const Bridge: NextPage = () => {
   const { switchNetwork, isSuccess } = useSwitchNetwork()
   const { chain } = useNetwork()
   const chainId = parseInt(config.chainId)
+  const {rate: exchangeRate} = useEveripediaRate()
+
   const {
     iqBalanceOnEth,
     pIQBalance,
@@ -256,16 +258,6 @@ const Bridge: NextPage = () => {
 
     if (authContext.activeUser) getIQonEosBalance()
   }, [authContext, balances])
-
-  useEffect(() => {
-    const getExchangeRate = async () => {
-      const rate = await getDollarValue()
-      setExchangeRate(rate)
-    }
-    if (!exchangeRate) {
-      getExchangeRate()
-    }
-  }, [exchangeRate])
 
   return (
     <>

--- a/src/pages/dashboard/stake.tsx
+++ b/src/pages/dashboard/stake.tsx
@@ -34,6 +34,7 @@ import StakeIQ from '@/components/lock/StakeIQ'
 import IncreaseLockTime from '@/components/lock/IncreaseLockTime'
 import { Dict } from '@chakra-ui/utils'
 import { NextSeo } from 'next-seo'
+import { useEveripediaRate } from '@/hooks/useRate'
 
 const Lock = () => {
   const [openUnlockNotification, setOpenUnlockNotification] = useState(false)
@@ -50,7 +51,7 @@ const Lock = () => {
   const { chain } = useNetwork()
   const chainId = parseInt(config.chainId)
   const { switchNetwork, isSuccess } = useSwitchNetwork()
-  const [exchangeRate, setExchangeRate] = useState(0)
+  const {rate: exchangeRate} = useEveripediaRate()
   const resetValues = () => {
     setIsProcessingUnlock(false)
     setTrxHash(undefined)
@@ -78,16 +79,6 @@ const Lock = () => {
       }
     }
   }, [data, checkPoint, toast, trxHash])
-
-  useEffect(() => {
-    const getExchangeRate = async () => {
-      const rate = await getDollarValue()
-      setExchangeRate(rate)
-    }
-    if (!exchangeRate) {
-      getExchangeRate()
-    }
-  }, [exchangeRate])
 
   const handleUnlock = async () => {
     setOpenUnlockNotification(false)

--- a/src/pages/dashboard/stake.tsx
+++ b/src/pages/dashboard/stake.tsx
@@ -29,7 +29,6 @@ import { useReward } from '@/hooks/useReward'
 import { useWaitForTransaction, useNetwork, useSwitchNetwork } from 'wagmi'
 import NetworkErrorNotification from '@/components/lock/NetworkErrorNotification'
 import config from '@/config'
-import { getDollarValue } from '@/utils/LockOverviewUtils'
 import StakeIQ from '@/components/lock/StakeIQ'
 import IncreaseLockTime from '@/components/lock/IncreaseLockTime'
 import { Dict } from '@chakra-ui/utils'
@@ -51,7 +50,7 @@ const Lock = () => {
   const { chain } = useNetwork()
   const chainId = parseInt(config.chainId)
   const { switchNetwork, isSuccess } = useSwitchNetwork()
-  const {rate: exchangeRate} = useEveripediaRate()
+  const { rate: exchangeRate } = useEveripediaRate()
   const resetValues = () => {
     setIsProcessingUnlock(false)
     setTrxHash(undefined)

--- a/src/pages/dashboard/stake.tsx
+++ b/src/pages/dashboard/stake.tsx
@@ -33,7 +33,7 @@ import StakeIQ from '@/components/lock/StakeIQ'
 import IncreaseLockTime from '@/components/lock/IncreaseLockTime'
 import { Dict } from '@chakra-ui/utils'
 import { NextSeo } from 'next-seo'
-import { useEveripediaRate } from '@/hooks/useRate'
+import { useIQRate } from '@/hooks/useRate'
 
 const Lock = () => {
   const [openUnlockNotification, setOpenUnlockNotification] = useState(false)
@@ -50,7 +50,7 @@ const Lock = () => {
   const { chain } = useNetwork()
   const chainId = parseInt(config.chainId)
   const { switchNetwork, isSuccess } = useSwitchNetwork()
-  const { rate: exchangeRate } = useEveripediaRate()
+  const { rate: exchangeRate } = useIQRate()
   const resetValues = () => {
     setIsProcessingUnlock(false)
     setTrxHash(undefined)

--- a/src/utils/LockOverviewUtils.ts
+++ b/src/utils/LockOverviewUtils.ts
@@ -48,7 +48,8 @@ export const getDollarValue = async () => {
   try {
     const a = await fetch(EP_COINGECKO_URL)
     const price = (await a.json()).everipedia.usd
-    return price
+    const result = await price as number
+    return result
   } catch (err) {
     return 0
   }

--- a/src/utils/LockOverviewUtils.ts
+++ b/src/utils/LockOverviewUtils.ts
@@ -48,7 +48,7 @@ export const getDollarValue = async () => {
   try {
     const a = await fetch(EP_COINGECKO_URL)
     const price = (await a.json()).everipedia.usd
-    const result = await price as number
+    const result = (await price) as number
     return result
   } catch (err) {
     return 0


### PR DESCRIPTION
there is a timer that refreshes value. make sure that happens each 5 seconds

if you open the tab network there are a lot of requests happening there, review that

everipedia price should not get into that timer, with once request its enough. price won't change considerably during the same session.

fixes https://github.com/EveripediaNetwork/issues/issues/860