### PR TITLE
fixes bug with time remaining

### DIFF
--- a/src/components/lock/LockedDetails.tsx
+++ b/src/components/lock/LockedDetails.tsx
@@ -72,7 +72,6 @@ const LockedDetails = ({
     if (lockEndDate && typeof lockEndDate !== 'number' && !daysDiff) {
       const currentDateTime = new Date().getTime()
       const lockedTime = lockEndDate.getTime()
-
       setIsExpired(currentDateTime > lockedTime)
       const differenceInDays =
         (lockedTime - currentDateTime) / (1000 * 3600 * 24)

--- a/src/hooks/useErc20.ts
+++ b/src/hooks/useErc20.ts
@@ -29,7 +29,7 @@ export const useErc20 = () => {
   const getUserBalance = () => {
     if (erc20Balance) {
       const result = formatContractResult(erc20Balance)
-      return result
+      return parseFloat(result.toFixed(3))
     }
     return 0
   }

--- a/src/utils/LockOverviewUtils.ts
+++ b/src/utils/LockOverviewUtils.ts
@@ -32,8 +32,8 @@ export const calculateAPR = (
 }
 
 export const formatContractResult = (value: Result | string) => {
-  const result = ethers.utils.formatEther(value) as unknown as number
-  return parseFloat(Number(result).toFixed(3))
+  const result = ethers.utils.formatEther(value) as unknown as string
+  return parseFloat(result)
 }
 
 export const getDollarValue = async () => {


### PR DESCRIPTION
There is a minor bug with the 'Increase stake time' on the staking page. (Both on desktop and mobile)

I've locked for 4 years and wanted to extend by 1 week as a few days have passed but it's allowing me to extend by more than 4 years (I'm sure the transaction won't go through though) I think it's a UI bug.
Also, the 'Time remaining' is sometimes blanked out

fixes https://github.com/EveripediaNetwork/issues/issues/867
