### PR TITLE
Reduce alchemy request

### DIFF
--- a/src/components/dashboard/ProfileSubMenu.tsx
+++ b/src/components/dashboard/ProfileSubMenu.tsx
@@ -1,234 +1,56 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import {
   Button,
-  Divider,
-  Flex,
   Popover,
   PopoverContent,
   PopoverTrigger,
   Text,
-  chakra,
-  IconProps,
-  useClipboard,
-  FlexProps,
-  ComponentWithAs,
-  Icon,
 } from '@chakra-ui/react'
-import {
-  RiLogoutBoxLine,
-  RiExternalLinkLine,
-  RiFileCopyLine,
-} from 'react-icons/ri'
 import shortenAccount from '@/utils/shortenAccount'
 import DisplayAvatar from '@/components/elements/Avatar/Avatar'
-import { useAccount, useDisconnect } from 'wagmi'
+import { useAccount } from 'wagmi'
 import { FaChevronDown } from 'react-icons/fa'
-import { IconType } from 'react-icons/lib'
-import { BraindaoLogo } from '@/components/braindao-logo'
-import { useFetchWalletBalance } from '@/components/wallet/use-fetch-wallet-balance'
-import { fetchRateAndCalculateTotalBalance } from '@/utils/fetch-wallet-balance'
-import {
-  getTokenValue,
-  useHiIQBalance,
-} from '@/components/wallet/use-hiiiq-balance'
-import { TokenDetailsType } from '@/components/wallet/types'
-import { tokenDetails } from '@/components/wallet/wallet-data'
-import { shortenBalance } from '@/utils/dashboard-utils'
-import { CheckIcon } from '@chakra-ui/icons'
-
-type SubMenuItemProps = {
-  label: string
-  action?: () => void
-  icon: IconType | ComponentWithAs<'svg'>
-} & FlexProps
-
-const SubMenuItem = (props: SubMenuItemProps) => {
-  const { icon, label, action, ...rest } = props
-  return (
-    <Flex
-      align="center"
-      color="fadedText4"
-      onClick={action}
-      px="6"
-      py="2.5"
-      gap="2"
-      cursor="pointer"
-      {...rest}
-    >
-      <Icon as={icon} boxSize="6" />
-      <Text fontWeight="bold">{label}</Text>
-    </Flex>
-  )
-}
-
-type TokenItemProps = {
-  symbol?: string
-  icon: (props: IconProps) => JSX.Element
-  amount: number
-  tokensArray: TokenDetailsType[] | null
-}
-
-const TokenItem = (props: TokenItemProps) => {
-  const { icon, symbol, amount, tokensArray } = props
-  if (!tokensArray) return null
-  return (
-    <Flex align="center" px="13px" py="3.5" gap="2.5" w="full">
-      <Icon as={icon} boxSize="6" />
-      <Text fontWeight="bold">{symbol}</Text>
-      <Flex
-        ml="auto"
-        direction="column"
-        align="space-between"
-        textAlign="right"
-      >
-        <Text fontWeight="bold">{shortenBalance(amount)}</Text>
-        <Text fontWeight="bold" fontSize="sm" color="fadedText5">
-          ${shortenBalance(getTokenValue(tokensArray, symbol))}
-        </Text>
-      </Flex>
-    </Flex>
-  )
-}
+import ProfileSubMenuDetails from './ProfileSubMenuDetails'
 
 const ProfileSubMenu = () => {
-  const { address, connector } = useAccount()
-  const { disconnect } = useDisconnect()
-  const logout = () => {
-    disconnect()
-  }
-
-  const { userBalance } = useFetchWalletBalance(address)
-
-  const [balanceBreakdown, setBalanceBreakdown] = useState<
-    TokenDetailsType[] | null
-  >(null)
-
-  const { hiiq } = useHiIQBalance(address)
-
-  const hiIQData = {
-    formatted: `${hiiq?.hiiqBalance}`,
-    symbol: `${hiiq?.symbol}`,
-    tokensArray: { price: hiiq?.totalUsdBalance ?? 0, token: 'HiIQ' },
-  }
-
-  useEffect(() => {
-    if (userBalance) {
-      fetchRateAndCalculateTotalBalance(userBalance).then(result => {
-        setBalanceBreakdown(result)
-      })
-    }
-  }, [userBalance])
-
-  const { hasCopied, onCopy: copyAddress } = useClipboard(address as string)
-
+  const { address } = useAccount()
   return (
     <Popover placement="bottom-start">
-      <PopoverTrigger>
-        <Button
-          size="md"
-          fontWeight="500"
-          variant="outline"
-          leftIcon={
-            <DisplayAvatar
-              svgProps={{ rounded: 'full' }}
-              size={20}
-              address={address}
-            />
-          }
-          rightIcon={<FaChevronDown />}
-        >
-          <Text fontSize="sm" fontWeight="medium">
-            {address && shortenAccount(address)}
-          </Text>
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        pt="5"
-        pb="6"
-        bg="bodyBg"
-        w="355px"
-        mr={{ md: '13', lg: '16' }}
-        boxShadow="2xl"
-      >
-        <chakra.div mx="6">
-          <Text fontWeight="bold">My Wallet</Text>
-          <Flex mt="3" align="center" gap="2.5">
-            <chakra.div pos="relative">
-              <DisplayAvatar
-                svgProps={{ rounded: 'full' }}
-                size={40}
-                address={address}
-              />
-              <chakra.div
-                boxSize="4"
-                bg="green.500"
-                pos="absolute"
-                bottom="-1"
-                rounded="full"
-                right="1"
-                border="solid 4px"
-                borderColor="bodyBg"
-              />
-            </chakra.div>
-            <Flex direction="column" align="space-between">
-              <Text fontWeight="bold" maxW="110px" noOfLines={1}>
-                {address}
+      {({ isOpen }) => (
+        <>
+          <PopoverTrigger>
+            <Button
+              size="md"
+              fontWeight="500"
+              variant="outline"
+              leftIcon={
+                <DisplayAvatar
+                  svgProps={{ rounded: 'full' }}
+                  size={20}
+                  address={address}
+                />
+              }
+              rightIcon={<FaChevronDown />}
+            >
+              <Text fontSize="sm" fontWeight="medium">
+                {address && shortenAccount(address)}
               </Text>
-              <Text color="dimmedText" fontWeight="semibold">
-                {connector?.name}
-              </Text>
-            </Flex>
-          </Flex>
-          <Flex mb="9" mt="4.5" rounded="md" bg="lightCard" direction="column">
-            {balanceBreakdown &&
-              userBalance &&
-              userBalance.length !== 0 &&
-              userBalance?.map((details, key) => {
-                if (!details?.data?.symbol) return null
-                return (
-                  <TokenItem
-                    key={key}
-                    symbol={details?.data?.symbol}
-                    icon={tokenDetails[details?.data?.symbol]?.logo}
-                    amount={Number(details?.data?.formatted)}
-                    tokensArray={balanceBreakdown}
-                  />
-                )
-              })}
-
-            {hiiq && userBalance && userBalance.length !== 0 && (
-              <TokenItem
-                symbol={hiIQData?.symbol}
-                icon={BraindaoLogo}
-                amount={Number(hiiq?.hiiqBalance)}
-                tokensArray={[hiIQData?.tokensArray]}
-              />
-            )}
-          </Flex>
-        </chakra.div>
-        <Divider mb="6" />
-        <SubMenuItem
-          label="Copy Address"
-          action={copyAddress}
-          icon={RiFileCopyLine}
-          {...(hasCopied && {
-            color: 'green',
-            icon: CheckIcon,
-          })}
-        />
-        <SubMenuItem
-          label="View on Etherscan"
-          action={() =>
-            window.open(`https://etherscan.io/address/${address}`, '_blank')
-          }
-          icon={RiExternalLinkLine}
-        />
-        <SubMenuItem
-          label="Disconnect"
-          action={logout}
-          icon={RiLogoutBoxLine}
-        />
-      </PopoverContent>
+            </Button>
+          </PopoverTrigger>
+          {isOpen && (
+            <PopoverContent
+              pt="5"
+              pb="6"
+              bg="bodyBg"
+              w="355px"
+              mr={{ md: '13', lg: '16' }}
+              boxShadow="2xl"
+            >
+              <ProfileSubMenuDetails />
+            </PopoverContent>
+          )}
+        </>
+      )}
     </Popover>
   )
 }

--- a/src/components/dashboard/ProfileSubMenuDetails.tsx
+++ b/src/components/dashboard/ProfileSubMenuDetails.tsx
@@ -30,60 +30,60 @@ import { tokenDetails } from '@/components/wallet/wallet-data'
 import { shortenBalance } from '@/utils/dashboard-utils'
 import { CheckIcon } from '@chakra-ui/icons'
 
-  type SubMenuItemProps = {
-    label: string
-    action?: () => void
-    icon: IconType | ComponentWithAs<'svg'>
-  } & FlexProps
-  
-  const SubMenuItem = (props: SubMenuItemProps) => {
-    const { icon, label, action, ...rest } = props
-    return (
+type SubMenuItemProps = {
+  label: string
+  action?: () => void
+  icon: IconType | ComponentWithAs<'svg'>
+} & FlexProps
+
+const SubMenuItem = (props: SubMenuItemProps) => {
+  const { icon, label, action, ...rest } = props
+  return (
+    <Flex
+      align="center"
+      color="fadedText4"
+      onClick={action}
+      px="6"
+      py="2.5"
+      gap="2"
+      cursor="pointer"
+      {...rest}
+    >
+      <Icon as={icon} boxSize="6" />
+      <Text fontWeight="bold">{label}</Text>
+    </Flex>
+  )
+}
+
+type TokenItemProps = {
+  symbol?: string
+  icon: (props: IconProps) => JSX.Element
+  amount: number
+  tokensArray: TokenDetailsType[] | null
+}
+
+const TokenItem = (props: TokenItemProps) => {
+  const { icon, symbol, amount, tokensArray } = props
+  if (!tokensArray) return null
+  return (
+    <Flex align="center" px="13px" py="3.5" gap="2.5" w="full">
+      <Icon as={icon} boxSize="6" />
+      <Text fontWeight="bold">{symbol}</Text>
       <Flex
-        align="center"
-        color="fadedText4"
-        onClick={action}
-        px="6"
-        py="2.5"
-        gap="2"
-        cursor="pointer"
-        {...rest}
+        ml="auto"
+        direction="column"
+        align="space-between"
+        textAlign="right"
       >
-        <Icon as={icon} boxSize="6" />
-        <Text fontWeight="bold">{label}</Text>
+        <Text fontWeight="bold">{shortenBalance(amount)}</Text>
+        <Text fontWeight="bold" fontSize="sm" color="fadedText5">
+          ${shortenBalance(getTokenValue(tokensArray, symbol))}
+        </Text>
       </Flex>
-    )
-  }
-  
-  type TokenItemProps = {
-    symbol?: string
-    icon: (props: IconProps) => JSX.Element
-    amount: number
-    tokensArray: TokenDetailsType[] | null
-  }
-  
-  const TokenItem = (props: TokenItemProps) => {
-    const { icon, symbol, amount, tokensArray } = props
-    if (!tokensArray) return null
-    return (
-      <Flex align="center" px="13px" py="3.5" gap="2.5" w="full">
-        <Icon as={icon} boxSize="6" />
-        <Text fontWeight="bold">{symbol}</Text>
-        <Flex
-          ml="auto"
-          direction="column"
-          align="space-between"
-          textAlign="right"
-        >
-          <Text fontWeight="bold">{shortenBalance(amount)}</Text>
-          <Text fontWeight="bold" fontSize="sm" color="fadedText5">
-            ${shortenBalance(getTokenValue(tokensArray, symbol))}
-          </Text>
-        </Flex>
-      </Flex>
-    )
-  }
-  
+    </Flex>
+  )
+}
+
 const ProfileSubMenuDetails = () => {
   const { address, connector } = useAccount()
   const { disconnect } = useDisconnect()

--- a/src/components/dashboard/ProfileSubMenuDetails.tsx
+++ b/src/components/dashboard/ProfileSubMenuDetails.tsx
@@ -1,0 +1,195 @@
+import React, { useEffect, useState, memo } from 'react'
+import {
+  Divider,
+  Flex,
+  Text,
+  chakra,
+  IconProps,
+  useClipboard,
+  FlexProps,
+  ComponentWithAs,
+  Icon,
+} from '@chakra-ui/react'
+import {
+  RiLogoutBoxLine,
+  RiExternalLinkLine,
+  RiFileCopyLine,
+} from 'react-icons/ri'
+import DisplayAvatar from '@/components/elements/Avatar/Avatar'
+import { useAccount, useDisconnect } from 'wagmi'
+import { IconType } from 'react-icons/lib'
+import { BraindaoLogo } from '@/components/braindao-logo'
+import { useFetchWalletBalance } from '@/components/wallet/use-fetch-wallet-balance'
+import { fetchRateAndCalculateTotalBalance } from '@/utils/fetch-wallet-balance'
+import {
+  getTokenValue,
+  useHiIQBalance,
+} from '@/components/wallet/use-hiiiq-balance'
+import { TokenDetailsType } from '@/components/wallet/types'
+import { tokenDetails } from '@/components/wallet/wallet-data'
+import { shortenBalance } from '@/utils/dashboard-utils'
+import { CheckIcon } from '@chakra-ui/icons'
+
+  type SubMenuItemProps = {
+    label: string
+    action?: () => void
+    icon: IconType | ComponentWithAs<'svg'>
+  } & FlexProps
+  
+  const SubMenuItem = (props: SubMenuItemProps) => {
+    const { icon, label, action, ...rest } = props
+    return (
+      <Flex
+        align="center"
+        color="fadedText4"
+        onClick={action}
+        px="6"
+        py="2.5"
+        gap="2"
+        cursor="pointer"
+        {...rest}
+      >
+        <Icon as={icon} boxSize="6" />
+        <Text fontWeight="bold">{label}</Text>
+      </Flex>
+    )
+  }
+  
+  type TokenItemProps = {
+    symbol?: string
+    icon: (props: IconProps) => JSX.Element
+    amount: number
+    tokensArray: TokenDetailsType[] | null
+  }
+  
+  const TokenItem = (props: TokenItemProps) => {
+    const { icon, symbol, amount, tokensArray } = props
+    if (!tokensArray) return null
+    return (
+      <Flex align="center" px="13px" py="3.5" gap="2.5" w="full">
+        <Icon as={icon} boxSize="6" />
+        <Text fontWeight="bold">{symbol}</Text>
+        <Flex
+          ml="auto"
+          direction="column"
+          align="space-between"
+          textAlign="right"
+        >
+          <Text fontWeight="bold">{shortenBalance(amount)}</Text>
+          <Text fontWeight="bold" fontSize="sm" color="fadedText5">
+            ${shortenBalance(getTokenValue(tokensArray, symbol))}
+          </Text>
+        </Flex>
+      </Flex>
+    )
+  }
+  
+const ProfileSubMenuDetails = () => {
+  const { address, connector } = useAccount()
+  const { disconnect } = useDisconnect()
+  const logout = () => {
+    disconnect()
+  }
+  const { userBalance } = useFetchWalletBalance(address)
+  const [balanceBreakdown, setBalanceBreakdown] = useState<
+    TokenDetailsType[] | null
+  >(null)
+
+  const { hiiq } = useHiIQBalance(address)
+
+  const hiIQData = {
+    formatted: `${hiiq?.hiiqBalance}`,
+    symbol: `${hiiq?.symbol}`,
+    tokensArray: { price: hiiq?.totalUsdBalance ?? 0, token: 'HiIQ' },
+  }
+
+  useEffect(() => {
+    if (userBalance) {
+      fetchRateAndCalculateTotalBalance(userBalance).then(result => {
+        setBalanceBreakdown(result)
+      })
+    }
+  }, [userBalance])
+
+  const { hasCopied, onCopy: copyAddress } = useClipboard(address as string)
+  return (
+    <>
+      <chakra.div mx="6">
+        <Text fontWeight="bold">My Wallet</Text>
+        <Flex mt="3" align="center" gap="2.5">
+          <chakra.div pos="relative">
+            <DisplayAvatar
+              svgProps={{ rounded: 'full' }}
+              size={40}
+              address={address}
+            />
+            <chakra.div
+              boxSize="4"
+              bg="green.500"
+              pos="absolute"
+              bottom="-1"
+              rounded="full"
+              right="1"
+              border="solid 4px"
+              borderColor="bodyBg"
+            />
+          </chakra.div>
+          <Flex direction="column" align="space-between">
+            <Text fontWeight="bold" maxW="110px" noOfLines={1}>
+              {address}
+            </Text>
+            <Text color="dimmedText" fontWeight="semibold">
+              {connector?.name}
+            </Text>
+          </Flex>
+        </Flex>
+        <Flex mb="9" mt="4.5" rounded="md" bg="lightCard" direction="column">
+          {balanceBreakdown &&
+            userBalance &&
+            userBalance.length !== 0 &&
+            userBalance?.map((details, key) => {
+              if (!details?.data?.symbol) return null
+              return (
+                <TokenItem
+                  key={key}
+                  symbol={details?.data?.symbol}
+                  icon={tokenDetails[details?.data?.symbol]?.logo}
+                  amount={Number(details?.data?.formatted)}
+                  tokensArray={balanceBreakdown}
+                />
+              )
+            })}
+
+          {hiiq && userBalance && userBalance.length !== 0 && (
+            <TokenItem
+              symbol={hiIQData?.symbol}
+              icon={BraindaoLogo}
+              amount={Number(hiiq?.hiiqBalance)}
+              tokensArray={[hiIQData?.tokensArray]}
+            />
+          )}
+        </Flex>
+      </chakra.div>
+      <Divider mb="6" />
+      <SubMenuItem
+        label="Copy Address"
+        action={copyAddress}
+        icon={RiFileCopyLine}
+        {...(hasCopied && {
+          color: 'green',
+          icon: CheckIcon,
+        })}
+      />
+      <SubMenuItem
+        label="View on Etherscan"
+        action={() =>
+          window.open(`https://etherscan.io/address/${address}`, '_blank')
+        }
+        icon={RiExternalLinkLine}
+      />
+      <SubMenuItem label="Disconnect" action={logout} icon={RiLogoutBoxLine} />
+    </>
+  )
+}
+
+export default memo(ProfileSubMenuDetails)

--- a/src/components/lock/IncreaseLockTime.tsx
+++ b/src/components/lock/IncreaseLockTime.tsx
@@ -14,7 +14,7 @@ import LockSlider from '../elements/Slider/LockSlider'
 const IncreaseLockTime = () => {
   const { increaseLockPeriod } = useLock()
   const [loading, setLoading] = useState(false)
-  const { userTotalIQLocked, lockEndDate } = useLockOverview()
+  const { userTotalIQLocked, lockEndDate, refetchUserLockEndDate } = useLockOverview()
   const [trxHash, setTrxHash] = useState()
   const toast = useToast()
   const [lockend, setLockend] = useState<Date>()
@@ -29,6 +29,7 @@ const IncreaseLockTime = () => {
     setLoading(false)
     setLockValue(0)
     setTrxHash(undefined)
+    refetchUserLockEndDate()
   }
 
   useEffect(() => {

--- a/src/components/lock/IncreaseLockTime.tsx
+++ b/src/components/lock/IncreaseLockTime.tsx
@@ -14,7 +14,8 @@ import LockSlider from '../elements/Slider/LockSlider'
 const IncreaseLockTime = () => {
   const { increaseLockPeriod } = useLock()
   const [loading, setLoading] = useState(false)
-  const { userTotalIQLocked, lockEndDate, refetchUserLockEndDate } = useLockOverview()
+  const { userTotalIQLocked, lockEndDate, refetchUserLockEndDate } =
+    useLockOverview()
   const [trxHash, setTrxHash] = useState()
   const toast = useToast()
   const [lockend, setLockend] = useState<Date>()

--- a/src/components/lock/LockedDetails.tsx
+++ b/src/components/lock/LockedDetails.tsx
@@ -69,7 +69,7 @@ const LockedDetails = ({
   }, [totalRewardEarned, isConnected, rewardEarned])
 
   useEffect(() => {
-    if (lockEndDate && typeof lockEndDate !== 'number' && !daysDiff) {
+    if (lockEndDate && typeof lockEndDate !== 'number') {
       const currentDateTime = new Date().getTime()
       const lockedTime = lockEndDate.getTime()
       setIsExpired(currentDateTime > lockedTime)

--- a/src/components/lock/StakeIQ.tsx
+++ b/src/components/lock/StakeIQ.tsx
@@ -19,7 +19,7 @@ import { RiArrowDownLine } from 'react-icons/ri'
 import { useErc20 } from '@/hooks/useErc20'
 import { useLock } from '@/hooks/useLock'
 import { useAccount, useWaitForTransaction } from 'wagmi'
-import { useLockOverview } from '@/hooks/useLockOverview'
+import { useLockOverview} from '@/hooks/useLockOverview'
 import { useReward } from '@/hooks/useReward'
 import { Dict } from '@chakra-ui/utils'
 import { logEvent } from '@/utils/googleAnalytics'
@@ -36,7 +36,7 @@ const StakeIQ = ({ exchangeRate }: { exchangeRate: number }) => {
   const toast = useToast()
   const { userTokenBalance } = useErc20()
   const { lockIQ, increaseLockAmount } = useLock()
-  const { userTotalIQLocked, lockEndDate } = useLockOverview()
+  const { userTotalIQLocked, lockEndDate, refreshTotalIQLocked, refetchUserLockEndDate } = useLockOverview()
   const { checkPoint } = useReward()
   const { data } = useWaitForTransaction({ hash: trxHash })
   const { isConnected, address } = useAccount()
@@ -74,6 +74,8 @@ const StakeIQ = ({ exchangeRate }: { exchangeRate: number }) => {
   }
 
   const resetValues = () => {
+    refreshTotalIQLocked()
+    refetchUserLockEndDate()
     setLoading(false)
     setIqToBeLocked(BigNumber.from(0))
     setUserInput(0)

--- a/src/components/lock/StakeIQ.tsx
+++ b/src/components/lock/StakeIQ.tsx
@@ -19,7 +19,7 @@ import { RiArrowDownLine } from 'react-icons/ri'
 import { useErc20 } from '@/hooks/useErc20'
 import { useLock } from '@/hooks/useLock'
 import { useAccount, useWaitForTransaction } from 'wagmi'
-import { useLockOverview} from '@/hooks/useLockOverview'
+import { useLockOverview } from '@/hooks/useLockOverview'
 import { useReward } from '@/hooks/useReward'
 import { Dict } from '@chakra-ui/utils'
 import { logEvent } from '@/utils/googleAnalytics'
@@ -36,7 +36,12 @@ const StakeIQ = ({ exchangeRate }: { exchangeRate: number }) => {
   const toast = useToast()
   const { userTokenBalance } = useErc20()
   const { lockIQ, increaseLockAmount } = useLock()
-  const { userTotalIQLocked, lockEndDate, refreshTotalIQLocked, refetchUserLockEndDate } = useLockOverview()
+  const {
+    userTotalIQLocked,
+    lockEndDate,
+    refreshTotalIQLocked,
+    refetchUserLockEndDate,
+  } = useLockOverview()
   const { checkPoint } = useReward()
   const { data } = useWaitForTransaction({ hash: trxHash })
   const { isConnected, address } = useAccount()

--- a/src/hooks/useErc20.ts
+++ b/src/hooks/useErc20.ts
@@ -3,7 +3,7 @@ import { erc20 } from '@/config/abis'
 import { formatContractResult } from '@/utils/LockOverviewUtils'
 import { ContractInterface } from '@ethersproject/contracts'
 import { BigNumber } from 'ethers'
-import { useAccount, useContractRead } from 'wagmi'
+import { useAccount, useBalance, useContractRead } from 'wagmi'
 
 const readContract = {
   addressOrName: config.iqAddress,
@@ -13,12 +13,9 @@ const readContract = {
 export const useErc20 = () => {
   const { address } = useAccount()
 
-  const { data: erc20Balance } = useContractRead({
-    ...readContract,
-    functionName: 'balanceOf',
-    args: [address],
-    watch: true,
-    staleTime: 5000,
+  const { data: erc20Balance } = useBalance({
+    addressOrName: address,
+    token: config.iqAddress,
   })
 
   const { data: totalValueLocked } = useContractRead({
@@ -28,7 +25,7 @@ export const useErc20 = () => {
   })
 
   const getUserBalance = () => {
-    return (erc20Balance as unknown as BigNumber) ?? 0
+    return (erc20Balance?.value as unknown as BigNumber) ?? 0
   }
 
   const tvl = () => {

--- a/src/hooks/useLockOverview.ts
+++ b/src/hooks/useLockOverview.ts
@@ -36,8 +36,8 @@ export const useLockOverview = () => {
     functionName: 'locked__end',
     args: [address],
     overrides: { gasLimit: DEFAULT_GAS_LIMIT },
-    watch: true,
-    staleTime: 5000,
+    // watch: true,
+    // staleTime: 5000,
   })
 
   const {
@@ -49,8 +49,8 @@ export const useLockOverview = () => {
     functionName: 'locked',
     args: [address],
     overrides: { gasLimit: DEFAULT_GAS_LIMIT },
-    watch: true,
-    staleTime: 5000,
+    // watch: true,
+    // staleTime: 5000,
   })
 
   const getTotalHiiqSupply = () => {

--- a/src/hooks/useLockOverview.ts
+++ b/src/hooks/useLockOverview.ts
@@ -31,18 +31,19 @@ export const useLockOverview = () => {
     overrides: { gasLimit: DEFAULT_GAS_LIMIT },
   })
 
-  const { data: lockEndDate, refetch: refetchUserLockEndDate } = useContractRead({
-    ...readContract,
-    functionName: 'locked__end',
-    args: [address],
-    overrides: { gasLimit: DEFAULT_GAS_LIMIT },
-  })
+  const { data: lockEndDate, refetch: refetchUserLockEndDate } =
+    useContractRead({
+      ...readContract,
+      functionName: 'locked__end',
+      args: [address],
+      overrides: { gasLimit: DEFAULT_GAS_LIMIT },
+    })
 
   const {
     data: totalLockedIq,
     isError: totalLockedIqError,
     isLoading: isFetchingTotalLockIq,
-    refetch: refetchTotalLockedIQ
+    refetch: refetchTotalLockedIQ,
   } = useContractRead({
     ...readContract,
     functionName: 'locked',
@@ -107,6 +108,6 @@ export const useLockOverview = () => {
     getMaximumLockablePeriod: (lockEnd: Date) =>
       getMaximumLockablePeriod(lockEnd),
     refreshTotalIQLocked: () => refetchTotalLockedIQ(),
-    refetchUserLockEndDate: () => refetchUserLockEndDate()
+    refetchUserLockEndDate: () => refetchUserLockEndDate(),
   }
 }

--- a/src/hooks/useLockOverview.ts
+++ b/src/hooks/useLockOverview.ts
@@ -31,26 +31,23 @@ export const useLockOverview = () => {
     overrides: { gasLimit: DEFAULT_GAS_LIMIT },
   })
 
-  const { data: lockEndDate } = useContractRead({
+  const { data: lockEndDate, refetch: refetchUserLockEndDate } = useContractRead({
     ...readContract,
     functionName: 'locked__end',
     args: [address],
     overrides: { gasLimit: DEFAULT_GAS_LIMIT },
-    // watch: true,
-    // staleTime: 5000,
   })
 
   const {
     data: totalLockedIq,
     isError: totalLockedIqError,
     isLoading: isFetchingTotalLockIq,
+    refetch: refetchTotalLockedIQ
   } = useContractRead({
     ...readContract,
     functionName: 'locked',
     args: [address],
     overrides: { gasLimit: DEFAULT_GAS_LIMIT },
-    // watch: true,
-    // staleTime: 5000,
   })
 
   const getTotalHiiqSupply = () => {
@@ -109,5 +106,7 @@ export const useLockOverview = () => {
     lockEndDate: getUserLockEndDate(),
     getMaximumLockablePeriod: (lockEnd: Date) =>
       getMaximumLockablePeriod(lockEnd),
+    refreshTotalIQLocked: () => refetchTotalLockedIQ(),
+    refetchUserLockEndDate: () => refetchUserLockEndDate()
   }
 }


### PR DESCRIPTION
stake page does 100 requests each few seconds to alchemy (this is probably some loops / unnecessary refreshes)

if you refresh the page https://iq.braindao.org/dashboard/stake it does 300 requests to load data.

idle in the homepage it refreshes balances every few seconds doing multiple requests for IQ and Hiiq (increase time to refresh or refresh when the user actually opens the menu w balances)

## Linked issues

fixes https://github.com/EveripediaNetwork/issues/issues/900