### PR TITLE
Removes watch on bridge hook

### DIFF
--- a/src/components/bridge/originInfo.tsx
+++ b/src/components/bridge/originInfo.tsx
@@ -3,8 +3,8 @@ import { useIQRate } from '@/hooks/useRate'
 import { Token, TokenId, getToken } from '@/types/bridge'
 import { shortenNumber } from '@/utils/shortenNumber.util'
 import { Input, Flex, Badge, Text } from '@chakra-ui/react'
-import { formatValue } from '@/utils/LockOverviewUtils'
 import { BraindaoLogo3 } from '../braindao-logo-3'
+import { formatValue, getValueFromBigNumber } from '@/utils/LockOverviewUtils'
 
 type OriginInfoType = {
   selectedToken: Token

--- a/src/components/bridge/originInfo.tsx
+++ b/src/components/bridge/originInfo.tsx
@@ -3,9 +3,8 @@ import { useIQRate } from '@/hooks/useRate'
 import { Token, TokenId, getToken } from '@/types/bridge'
 import { shortenNumber } from '@/utils/shortenNumber.util'
 import { Input, Flex, Badge, Text } from '@chakra-ui/react'
+import { formatValue } from '@/utils/LockOverviewUtils'
 import { BraindaoLogo3 } from '../braindao-logo-3'
-import { formatValue, getValueFromBigNumber } from '@/utils/LockOverviewUtils'
-
 
 type OriginInfoType = {
   selectedToken: Token
@@ -31,7 +30,7 @@ const OriginInfo = ({
           Send:
         </Text>
         <Flex gap="1" align="center">
-        <Input
+          <Input
             variant="unstyled"
             onChange={e => String(setTokenInputAmount(e.target.value))}
             placeholder="00.00"
@@ -41,7 +40,11 @@ const OriginInfo = ({
             fontSize="lg"
             fontWeight="semibold"
             display="inline-block"
-            w={tokenInputAmount ? `min(${(tokenInputAmount.toString().length + 2.3) * 9}px,50%)` : '30%'}
+            w={
+              tokenInputAmount
+                ? `min(${(tokenInputAmount.toString().length + 2.3) * 9}px,50%)`
+                : '30%'
+            }
           />
           <Text
             align="left"

--- a/src/components/bridge/originInfo.tsx
+++ b/src/components/bridge/originInfo.tsx
@@ -4,6 +4,8 @@ import { Token, TokenId, getToken } from '@/types/bridge'
 import { shortenNumber } from '@/utils/shortenNumber.util'
 import { Input, Flex, Badge, Text } from '@chakra-ui/react'
 import { BraindaoLogo3 } from '../braindao-logo-3'
+import { formatValue, getValueFromBigNumber } from '@/utils/LockOverviewUtils'
+
 
 type OriginInfoType = {
   selectedToken: Token
@@ -29,19 +31,17 @@ const OriginInfo = ({
           Send:
         </Text>
         <Flex gap="1" align="center">
-          <Input
-            sx={{
-              all: 'unset',
-              fontWeight: 'semibold',
-              color: 'fadedText4',
-            }}
-            w="100% !important"
-            disabled={isBalanceZero()}
-            placeholder="00.00"
-            type="number"
-            value={tokenInputAmount}
+        <Input
+            variant="unstyled"
             onChange={e => String(setTokenInputAmount(e.target.value))}
-            autoFocus
+            placeholder="00.00"
+            value={tokenInputAmount}
+            color="fadedText4"
+            disabled={isBalanceZero()}
+            fontSize="lg"
+            fontWeight="semibold"
+            display="inline-block"
+            w={tokenInputAmount ? `min(${(tokenInputAmount.toString().length + 2.3) * 9}px,50%)` : '30%'}
           />
           <Text
             align="left"
@@ -73,7 +73,7 @@ const OriginInfo = ({
             fontSize="xs"
             fontWeight="medium"
           >
-            Balance: {getSpecificBalance(selectedToken.id)}
+            Balance: {formatValue(getSpecificBalance(selectedToken.id))}
           </Text>
           <Badge
             onClick={() =>

--- a/src/components/bridge/originInfo.tsx
+++ b/src/components/bridge/originInfo.tsx
@@ -3,8 +3,8 @@ import { useIQRate } from '@/hooks/useRate'
 import { Token, TokenId, getToken } from '@/types/bridge'
 import { shortenNumber } from '@/utils/shortenNumber.util'
 import { Input, Flex, Badge, Text } from '@chakra-ui/react'
+import { formatValue } from '@/utils/LockOverviewUtils'
 import { BraindaoLogo3 } from '../braindao-logo-3'
-import { formatValue, getValueFromBigNumber } from '@/utils/LockOverviewUtils'
 
 type OriginInfoType = {
   selectedToken: Token
@@ -42,7 +42,7 @@ const OriginInfo = ({
             display="inline-block"
             w={
               tokenInputAmount
-                ? `min(${(tokenInputAmount.toString().length + 2.3) * 9}px,50%)`
+                ? `min(${(tokenInputAmount.toString().length + 3.5) * 9}px,60%)`
                 : '30%'
             }
           />

--- a/src/hooks/useBridge.ts
+++ b/src/hooks/useBridge.ts
@@ -1,11 +1,12 @@
 import {
   useAccount,
+  useBalance,
   useContract,
   useContractRead,
   useContractWrite,
   useSigner,
 } from 'wagmi'
-import { BigNumber, Signer, utils, constants, Contract } from 'ethers'
+import { BigNumber, Signer, utils, constants, Contract, ethers } from 'ethers'
 import { erc20Abi } from '@/abis/erc20.abi'
 import { minterAbi } from '@/abis/minter.abi'
 import { ptokenAbi } from '@/abis/ptoken.abi'
@@ -34,20 +35,14 @@ export const useBridge = () => {
     functionName: 'redeem',
   })
 
-  const { data: pTokenBalance } = useContractRead({
-    addressOrName: config.pIqAddress,
-    contractInterface: erc20Abi,
-    functionName: 'balanceOf',
-    watch: true,
-    args: [address],
+  const { data: pTokenBalance } = useBalance({
+    addressOrName: address,
+    token: config.pIqAddress,
   })
 
-  const { data: iqBalance } = useContractRead({
-    addressOrName: config.iqAddress,
-    contractInterface: erc20Abi,
-    functionName: 'balanceOf',
-    watch: true,
-    args: [address],
+  const { data: iqBalance } = useBalance({
+    addressOrName: address,
+    token: config.iqAddress,
   })
 
   const iqErc20Contract = useContract({
@@ -75,14 +70,12 @@ export const useBridge = () => {
   }
 
   const getPIQBalance = () => {
-    if (pTokenBalance) return utils.formatEther(pTokenBalance)
-
+    if (pTokenBalance) return ethers.utils.formatEther(pTokenBalance.value)
     return '0'
   }
 
   const getIQBalanceOnEth = () => {
-    if (iqBalance) return utils.formatEther(iqBalance)
-
+    if (iqBalance) return ethers.utils.formatEther(iqBalance.value)
     return '0'
   }
 

--- a/src/hooks/useBridge.ts
+++ b/src/hooks/useBridge.ts
@@ -5,7 +5,7 @@ import {
   useContractWrite,
   useSigner,
 } from 'wagmi'
-import { BigNumber, Signer, utils, constants, Contract, ethers } from 'ethers'
+import { BigNumber, Signer, utils, constants, Contract } from 'ethers'
 import { erc20Abi } from '@/abis/erc20.abi'
 import { minterAbi } from '@/abis/minter.abi'
 import { ptokenAbi } from '@/abis/ptoken.abi'
@@ -69,12 +69,12 @@ export const useBridge = () => {
   }
 
   const getPIQBalance = () => {
-    if (pTokenBalance) return ethers.utils.formatEther(pTokenBalance.value)
+    if (pTokenBalance) return utils.formatEther(pTokenBalance.value)
     return '0'
   }
 
   const getIQBalanceOnEth = () => {
-    if (iqBalance) return ethers.utils.formatEther(iqBalance.value)
+    if (iqBalance) return utils.formatEther(iqBalance.value)
     return '0'
   }
 

--- a/src/hooks/useBridge.ts
+++ b/src/hooks/useBridge.ts
@@ -2,7 +2,6 @@ import {
   useAccount,
   useBalance,
   useContract,
-  useContractRead,
   useContractWrite,
   useSigner,
 } from 'wagmi'

--- a/src/utils/stats-data.ts
+++ b/src/utils/stats-data.ts
@@ -116,7 +116,7 @@ const getVolume = async () => {
 
   const maticBalance = maticVolume?.balance ?? 0
   const bscBalance = bscVolume?.balance ?? 0
-  // TODO: get https://www.bloks.io/account/xeth.ptokens balance and remove it to eosVolume 
+  // TODO: get https://www.bloks.io/account/xeth.ptokens balance and remove it to eosVolume
   return {
     volume: {
       eos: eosVolume,


### PR DESCRIPTION
# Remove 'watch' keys in the bridge hook

To avoid performing extra and unnecessary requests it is better to use re-fetch instead of using the watch key

## Linked issues

fixes https://github.com/EveripediaNetwork/issues/issues/910