### PR TITLE
Fix apr issue

### DIFF
--- a/src/data/LockConstants.tsx
+++ b/src/data/LockConstants.tsx
@@ -9,28 +9,31 @@ export const EP_COINGECKO_URL =
 export const IQ_TOKEN_HOLDER =
   'https://ethplorer.io/service/service.php?data=0x1bf5457ecaa14ff63cc89efd560e251e814e16ba&page=pageSize%3D600%26pageTab%3Dholders%26tab%3Dtab-holders&showTx=all'
 export const NORMALIZE_VALUE = 10e17
+const REWARDS_FOR_THE_FIRST_YEAR = 1095000000 // 3M per day for 365 days
 
-const REWARDS_FOR_THE_FIRST_YEAR = 1095000000
-const REWARDS_FOR_THE_SECOND_YEAR = 547500000
-const REWARDS_FOR_THE_THIRD_YEAR = 273750000
-const REWARDS_FOR_THE_FOURTH_YEAR = 136875000
-const REWARDS_FOR_THE_FIFTH_YEAR = 68437500
-
-const rewards = {
-  1: REWARDS_FOR_THE_SECOND_YEAR,
-  2: REWARDS_FOR_THE_THIRD_YEAR,
-  3: REWARDS_FOR_THE_FOURTH_YEAR,
-  4: REWARDS_FOR_THE_FIFTH_YEAR,
-}
-
-export const TOTAL_REWARDS_ACROSS_LOCK_PERIOD = (): number => {
+export const getTotalIQMintedPerYear = (year = 0): number => {
   const newModelStartDate = new Date('November 1, 2022')
-  const diffInMiliseconds = Date.now() - newModelStartDate.getTime()
+  const currentDate = new Date()
+  currentDate.setFullYear(currentDate.getFullYear() + year)
+  const diffInMiliseconds = currentDate.getTime() - newModelStartDate.getTime()
   const yearsOfDifference = Math.abs(
     new Date(diffInMiliseconds).getUTCFullYear() - 1970,
   )
-
   if (yearsOfDifference === 0) return REWARDS_FOR_THE_FIRST_YEAR
+  return REWARDS_FOR_THE_FIRST_YEAR / 2 ** yearsOfDifference // halving model suggests that every year, the reward halfs its initial amount... i.e (1/ 2^n) where n is the number of yrs
+}
 
-  return Object.values(rewards)[yearsOfDifference - 1]
+export const calculateUserPoolRewardOverTheYear = (
+  years: number,
+  userTotalIQLocked: number,
+  totalHIIQ: number,
+) => {
+  let totalPoolReward = 0
+  for (let i = 0; i < years; i+=1) {
+    const totalIQMintedEachYear = getTotalIQMintedPerYear(i)
+    const userPoolRationForTheYear =
+      (userTotalIQLocked / totalHIIQ) * totalIQMintedEachYear
+    totalPoolReward += userPoolRationForTheYear
+  }
+  return totalPoolReward
 }

--- a/src/data/LockConstants.tsx
+++ b/src/data/LockConstants.tsx
@@ -29,7 +29,7 @@ export const calculateUserPoolRewardOverTheYear = (
   totalHIIQ: number,
 ) => {
   let totalPoolReward = 0
-  for (let i = 0; i < years; i+=1) {
+  for (let i = 0; i < years; i += 1) {
     const totalIQMintedEachYear = getTotalIQMintedPerYear(i)
     const userPoolRationForTheYear =
       (userTotalIQLocked / totalHIIQ) * totalIQMintedEachYear

--- a/src/utils/LockOverviewUtils.ts
+++ b/src/utils/LockOverviewUtils.ts
@@ -19,7 +19,7 @@ export const calculateUserReward = (
   const totalPoolRewardForTheLockYear = calculateUserPoolRewardOverTheYear(
     yearsLocked,
     amountLocked,
-    2487626651,
+    totalHiiq,
   )
   return totalPoolRewardForTheLockYear + rewardsBasedOnLockPeriod
 }
@@ -29,7 +29,7 @@ export const calculateAPR = (
   totalLockedIq: number,
   years: number,
 ) => {
-  const testHiiq = 2487626651
+  const testHiiq = totalHiiq
   const amountLocked = totalLockedIq > 0 ? totalLockedIq : 1000000
   const userRewardsPlusInitialLock =
     calculateUserReward(testHiiq, years, amountLocked) + amountLocked

--- a/src/utils/LockOverviewUtils.ts
+++ b/src/utils/LockOverviewUtils.ts
@@ -30,8 +30,11 @@ export const calculateAPR = (
   years: number,
 ) => {
   const amountLocked = totalLockedIq > 0 ? totalLockedIq : 1000000
-  const userRewardsPlusInitialLock =
-    calculateUserReward(totalHiiq, years, amountLocked)
+  const userRewardsPlusInitialLock = calculateUserReward(
+    totalHiiq,
+    years,
+    amountLocked,
+  )
   const aprAcrossLockPeriod = userRewardsPlusInitialLock / amountLocked
   const aprDividedByLockPeriod = aprAcrossLockPeriod * 100
   return aprDividedByLockPeriod

--- a/src/utils/LockOverviewUtils.ts
+++ b/src/utils/LockOverviewUtils.ts
@@ -19,7 +19,7 @@ export const calculateUserReward = (
   const totalPoolRewardForTheLockYear = calculateUserPoolRewardOverTheYear(
     yearsLocked,
     amountLocked,
-    totalHiiq,
+    2495400744.67,
   )
   return totalPoolRewardForTheLockYear + rewardsBasedOnLockPeriod
 }
@@ -31,7 +31,7 @@ export const calculateAPR = (
 ) => {
   const amountLocked = totalLockedIq > 0 ? totalLockedIq : 1000000
   const userRewardsPlusInitialLock = calculateUserReward(
-    totalHiiq,
+    2495400744.67,
     years,
     amountLocked,
   )

--- a/src/utils/LockOverviewUtils.ts
+++ b/src/utils/LockOverviewUtils.ts
@@ -29,10 +29,9 @@ export const calculateAPR = (
   totalLockedIq: number,
   years: number,
 ) => {
-  const testHiiq = totalHiiq
   const amountLocked = totalLockedIq > 0 ? totalLockedIq : 1000000
   const userRewardsPlusInitialLock =
-    calculateUserReward(testHiiq, years, amountLocked) + amountLocked
+    calculateUserReward(totalHiiq, years, amountLocked)
   const aprAcrossLockPeriod = userRewardsPlusInitialLock / amountLocked
   const aprDividedByLockPeriod = aprAcrossLockPeriod * 100
   return aprDividedByLockPeriod

--- a/src/utils/LockOverviewUtils.ts
+++ b/src/utils/LockOverviewUtils.ts
@@ -19,7 +19,7 @@ export const calculateUserReward = (
   const totalPoolRewardForTheLockYear = calculateUserPoolRewardOverTheYear(
     yearsLocked,
     amountLocked,
-    2495400744.67,
+    totalHiiq,
   )
   return totalPoolRewardForTheLockYear + rewardsBasedOnLockPeriod
 }
@@ -31,7 +31,7 @@ export const calculateAPR = (
 ) => {
   const amountLocked = totalLockedIq > 0 ? totalLockedIq : 1000000
   const userRewardsPlusInitialLock = calculateUserReward(
-    2495400744.67,
+    totalHiiq,
     years,
     amountLocked,
   )

--- a/src/utils/LockOverviewUtils.ts
+++ b/src/utils/LockOverviewUtils.ts
@@ -1,6 +1,6 @@
 import {
   YEARS_LOCK,
-  TOTAL_REWARDS_ACROSS_LOCK_PERIOD,
+  calculateUserPoolRewardOverTheYear,
   EP_COINGECKO_URL,
   IQ_TOKEN_HOLDER,
 } from '@/data/LockConstants'
@@ -14,10 +14,14 @@ export const calculateUserReward = (
   amountLocked: number,
 ) => {
   const yearsLocked = years || YEARS_LOCK
-  const rewardsBasedOnLockPeriod = amountLocked * (1 + 0.75 * yearsLocked)
-  const poolRatio =
-    rewardsBasedOnLockPeriod / (totalHiiq + rewardsBasedOnLockPeriod)
-  return TOTAL_REWARDS_ACROSS_LOCK_PERIOD() * yearsLocked * poolRatio
+  const rewardsBasedOnLockPeriod =
+    amountLocked + amountLocked * 3 * (yearsLocked / 4)
+  const totalPoolRewardForTheLockYear = calculateUserPoolRewardOverTheYear(
+    yearsLocked,
+    amountLocked,
+    2487626651,
+  )
+  return totalPoolRewardForTheLockYear + rewardsBasedOnLockPeriod
 }
 
 export const calculateAPR = (
@@ -25,11 +29,12 @@ export const calculateAPR = (
   totalLockedIq: number,
   years: number,
 ) => {
+  const testHiiq = 2487626651
   const amountLocked = totalLockedIq > 0 ? totalLockedIq : 1000000
   const userRewardsPlusInitialLock =
-    calculateUserReward(totalHiiq, years, amountLocked) + amountLocked
+    calculateUserReward(testHiiq, years, amountLocked) + amountLocked
   const aprAcrossLockPeriod = userRewardsPlusInitialLock / amountLocked
-  const aprDividedByLockPeriod = (aprAcrossLockPeriod / years) * 100
+  const aprDividedByLockPeriod = aprAcrossLockPeriod * 100
   return aprDividedByLockPeriod
 }
 


### PR DESCRIPTION
# HiIQ Staking Calculator APR bug

The HiIQ Staking Calculator seems to be displaying the wrong numbers.
For example, locking for:

1 Year lock = 187%
2 Year lock = 175%

Displaying less for a longer period of lock.

fixes https://github.com/EveripediaNetwork/issues/issues/904