### PR TITLE
IQ allowance staking issue

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,18 @@
+checks:
+  file-lines:
+    config:
+      threshold: 250
+  method-complexity:
+    config:
+      threshold: 22
+  method-lines:
+    enabled: true
+    config:
+      threshold: 140
+  similar-code:
+    enabled: true
+    config:
+      threshold: 65
+exclude_patterns:
+  - 'src/abis'
+  - 'src/hooks'

--- a/src/components/lock/StakeIQ.tsx
+++ b/src/components/lock/StakeIQ.tsx
@@ -182,7 +182,7 @@ const StakeIQ = ({ exchangeRate }: { exchangeRate: number }) => {
           setLoading(false)
           return
         }
-        if (result === 'allowance_error') {
+        if (result === 'ALLOWANCE_ERROR') {
           toast({
             title: `Allowance too small for this transaction`,
             position: 'top-right',

--- a/src/components/lock/StakeIQ.tsx
+++ b/src/components/lock/StakeIQ.tsx
@@ -161,7 +161,6 @@ const StakeIQ = ({ exchangeRate }: { exchangeRate: number }) => {
         isClosable: true,
         status: 'error',
       })
-      return
     }
     if (userTotalIQLocked > 0) {
       setLoading(true)

--- a/src/components/lock/StakeIQ.tsx
+++ b/src/components/lock/StakeIQ.tsx
@@ -183,6 +183,16 @@ const StakeIQ = ({ exchangeRate }: { exchangeRate: number }) => {
           setLoading(false)
           return
         }
+        if (result === 'allowance_error') {
+          toast({
+            title: `Allowance too small for this transaction`,
+            position: 'top-right',
+            isClosable: true,
+            status: 'error',
+          })
+          setLoading(false)
+          return
+        }
         logEvent({
           action: 'INCREASE_STAKE_SUCCESS',
           label: JSON.stringify(address),

--- a/src/hooks/useLock.ts
+++ b/src/hooks/useLock.ts
@@ -48,7 +48,7 @@ export const useLock = () => {
       address,
       config.hiiqAddress,
     )
-    return newAllowedTokens < amount ? false : true
+    return newAllowedTokens < amount
   }
 
   const lockIQ = async (amount: BigNumber, lockPeriod: number) => {

--- a/src/hooks/useLock.ts
+++ b/src/hooks/useLock.ts
@@ -56,7 +56,7 @@ export const useLock = () => {
       address,
       config.hiiqAddress,
     )
-    if (newAllowedTokens >= amount) {
+    if (newAllowedTokens.gte(amount)) {
       const result = await hiiqContracts.create_lock(
         amount,
         String(timeParsed),
@@ -75,7 +75,7 @@ export const useLock = () => {
       address,
       config.hiiqAddress,
     )
-    if (newAllowedTokens >= amount) {
+    if (newAllowedTokens.gte(amount)) {
       const result = await hiiqContracts.increase_amount(amount, {
         gasLimit: calculateGasBuffer(LOCK_UPDATE_GAS_LIMIT),
       })

--- a/src/hooks/useLock.ts
+++ b/src/hooks/useLock.ts
@@ -42,50 +42,30 @@ export const useLock = () => {
       config.hiiqAddress,
     )
     if (allowedTokens.lt(amount)) {
-      await erc20Contracts.approve(config.hiiqAddress, amount)
+      await erc20Contracts.approve(
+        config.hiiqAddress,
+        amount.sub(allowedTokens),
+      )
     }
-    const newAllowedTokens = await erc20Contracts.allowance(
-      address,
-      config.hiiqAddress,
-    )
-    console.log(
-      config.hiiqAddress,
-      config.iqAddress,
-      allowedTokens,
-      newAllowedTokens,
-      amount,
-    )
-    return newAllowedTokens < amount
   }
 
   const lockIQ = async (amount: BigNumber, lockPeriod: number) => {
     const convertedDate = new Date()
     convertedDate.setDate(convertedDate.getDate() + lockPeriod)
     const timeParsed = Math.floor(convertedDate.getTime() / 1000.0)
-    const approval = await needsApproval(amount)
-    if (approval) {
-      const result = await hiiqContracts.create_lock(
-        amount,
-        String(timeParsed),
-        {
-          gasLimit: calculateGasBuffer(LOCK_AND_WITHDRAWAL_GAS_LIMIT),
-        },
-      )
-      return result
-    }
-
-    return false
+    await needsApproval(amount)
+    const result = await hiiqContracts.create_lock(amount, String(timeParsed), {
+      gasLimit: calculateGasBuffer(LOCK_AND_WITHDRAWAL_GAS_LIMIT),
+    })
+    return result
   }
 
   const increaseLockAmount = async (amount: BigNumber) => {
-    const approval = await needsApproval(amount)
-    if (approval) {
-      const result = await hiiqContracts.increase_amount(amount, {
-        gasLimit: calculateGasBuffer(LOCK_UPDATE_GAS_LIMIT),
-      })
-      return result
-    }
-    return false
+    await needsApproval(amount)
+    const result = await hiiqContracts.increase_amount(amount, {
+      gasLimit: calculateGasBuffer(LOCK_UPDATE_GAS_LIMIT),
+    })
+    return result
   }
 
   const avoidMaxTimeUnlockTime = (unlockPeriod: number) => {

--- a/src/hooks/useLock.ts
+++ b/src/hooks/useLock.ts
@@ -48,6 +48,13 @@ export const useLock = () => {
       address,
       config.hiiqAddress,
     )
+    console.log(
+      config.hiiqAddress,
+      config.iqAddress,
+      allowedTokens,
+      newAllowedTokens,
+      amount,
+    )
     return newAllowedTokens < amount
   }
 

--- a/src/hooks/useLock.ts
+++ b/src/hooks/useLock.ts
@@ -42,8 +42,8 @@ export const useLock = () => {
       config.hiiqAddress,
     )
     if (allowedTokens.lt(amount)) {
-     const approval = await erc20Contracts.approve(config.hiiqAddress, amount)
-     await approval.wait()
+      const approval = await erc20Contracts.approve(config.hiiqAddress, amount)
+      await approval.wait()
     }
   }
 

--- a/src/hooks/useLock.ts
+++ b/src/hooks/useLock.ts
@@ -42,11 +42,8 @@ export const useLock = () => {
       config.hiiqAddress,
     )
     if (allowedTokens.lt(amount)) {
-      const approval = await erc20Contracts.approve(
-        config.hiiqAddress,
-        amount.sub(allowedTokens),
-      )
-      approval.wait()
+     const approval = await erc20Contracts.approve(config.hiiqAddress, amount)
+     await approval.wait()
     }
   }
 

--- a/src/hooks/useLock.ts
+++ b/src/hooks/useLock.ts
@@ -9,7 +9,7 @@ import {
   calculateGasBuffer,
 } from '@/utils/LockOverviewUtils'
 import { ContractInterface } from '@ethersproject/contracts'
-import { BigNumber, ethers, Signer } from 'ethers'
+import { BigNumber, Signer } from 'ethers'
 import { useAccount, useContract, useSigner } from 'wagmi'
 
 const hiiqContractConfig = {

--- a/src/hooks/useLock.ts
+++ b/src/hooks/useLock.ts
@@ -67,7 +67,6 @@ export const useLock = () => {
     }
     return 'ALLOWANCE_ERROR'
   }
-  
 
   const increaseLockAmount = async (amount: BigNumber) => {
     await needsApproval(amount)


### PR DESCRIPTION
# IQ Allowance staking issue

When staking now, a user needs to sign a transaction to allow the spending first before signing the actual stake transaction and due to the new feature of metamask, if the amount to be approved is reduced and the allowance amount is lesser than the original amount staked then the transaction fails.


## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/1064
