### PR TITLE
Fix bridge issue

### DIFF
--- a/src/components/wallet/wallet-data.ts
+++ b/src/components/wallet/wallet-data.ts
@@ -1,7 +1,7 @@
 import { BraindaoLogo } from '@/components/braindao-logo'
 import { Ethereum } from '@/components/icons/ethereum'
 import { Polygon } from '@/components/icons/polygon'
-import { IconProps } from '@chakra-ui/icon'
+import { IconProps } from '@chakra-ui/react'
 
 export const tokenDetails: {
   [key: string]: { name: string; logo: (props: IconProps) => JSX.Element }

--- a/src/data/SidebarData.ts
+++ b/src/data/SidebarData.ts
@@ -1,5 +1,5 @@
 import { BraindaoLogo } from '@/components/braindao-logo'
-import { IconProps } from '@chakra-ui/icon'
+import { IconProps } from '@chakra-ui/react'
 import { IconType } from 'react-icons/lib'
 import {
   RiAppsFill,

--- a/src/data/WalletData.ts
+++ b/src/data/WalletData.ts
@@ -4,4 +4,9 @@ import { Trevor } from '@/components/icons/trevor'
 import { WalletConnect } from '@/components/icons/walletconnect'
 import { IconProps } from '@chakra-ui/react'
 
-export const WALLET_LOGOS: ((props: IconProps) => JSX.Element)[] = [Metamask, WalletConnect, Coinbase, Trevor]
+export const WALLET_LOGOS: ((props: IconProps) => JSX.Element)[] = [
+  Metamask,
+  WalletConnect,
+  Coinbase,
+  Trevor,
+]

--- a/src/data/WalletData.ts
+++ b/src/data/WalletData.ts
@@ -2,5 +2,6 @@ import { Coinbase } from '@/components/icons/coinbase'
 import { Metamask } from '@/components/icons/metamask'
 import { Trevor } from '@/components/icons/trevor'
 import { WalletConnect } from '@/components/icons/walletconnect'
+import { IconProps } from '@chakra-ui/react'
 
-export const WALLET_LOGOS = [Metamask, WalletConnect, Coinbase, Trevor]
+export const WALLET_LOGOS: ((props: IconProps) => JSX.Element)[] = [Metamask, WalletConnect, Coinbase, Trevor]

--- a/src/data/treasury-data.ts
+++ b/src/data/treasury-data.ts
@@ -1,6 +1,6 @@
 import { BraindaoLogo } from '@/components/braindao-logo'
 import { FXS } from '@/components/icons/fxs'
-import { IconProps } from '@chakra-ui/icon'
+import { IconProps } from '@chakra-ui/react'
 import { WETH } from '@/components/icons/weth'
 import { Fraxswap } from '@/components/icons/fraxswap'
 import { SLP } from '@/components/icons/slp'

--- a/src/pages/dashboard/bridge.tsx
+++ b/src/pages/dashboard/bridge.tsx
@@ -78,9 +78,9 @@ const Bridge: NextPage = () => {
     let isError = false
     if (selectedToken.id === TokenId.EOS) {
       let msg = 'Tokens successfully bridge from EOS to the Ptoken bridge'
-      if(!address){
+      if (!address) {
         toast({
-          title: "Address cannot be empty",
+          title: 'Address cannot be empty',
           position: 'top-right',
           isClosable: true,
           status: 'error',

--- a/src/pages/dashboard/bridge.tsx
+++ b/src/pages/dashboard/bridge.tsx
@@ -78,10 +78,19 @@ const Bridge: NextPage = () => {
     let isError = false
     if (selectedToken.id === TokenId.EOS) {
       let msg = 'Tokens successfully bridge from EOS to the Ptoken bridge'
+      if(!address){
+        toast({
+          title: "Address cannot be empty",
+          position: 'top-right',
+          isClosable: true,
+          status: 'error',
+        })
+        return
+      }
       try {
         await convertTokensTx(
           `${parseFloat(tokenInputAmount).toFixed(3)} IQ`,
-          address || '',
+          address,
           authContext,
         )
       } catch (error) {

--- a/src/types/NetworkType.ts
+++ b/src/types/NetworkType.ts
@@ -1,4 +1,4 @@
-import { IconProps } from '@chakra-ui/icon'
+import { IconProps } from '@chakra-ui/react'
 
 export type NetworkType = {
   id: number


### PR DESCRIPTION
A user reported an issue with the IQ Bridge transfer from EOS to ETH where their account was not filled in the memo field. The user was only connected to the EOS chain using an EOS wallet and was not connected to Metamask or any similar service. The user clicked send and the memo field was left empty.

 We would to add more security to avoid sending EOS transfers with empty memo.
Here is the link: https://eosauthority.com/transaction/8f1632e4ff2dc21a1f21b8e8211fcb9cd1bfb7ea7ddbee7ed5cf3daaf0fed4c6?network=eos#traces

here we can see the empty memo transfer, so somehow its possible

fixes https://github.com/EveripediaNetwork/issues/issues/1100