### PR TITLE
updates the lock period default on the calculator

### DIFF
--- a/src/components/lock/RewardCalculator.tsx
+++ b/src/components/lock/RewardCalculator.tsx
@@ -57,7 +57,7 @@ const RewardCalculator = ({
   const { totalHiiqSupply } = useLockOverview()
   const [expectedReturn, setExpectedReward] = useState(0)
   const [inputIQ, setInputIQ] = useState(0)
-  const [years, setYears] = useState(0)
+  const [years, setYears] = useState(4)
 
   useEffect(() => {
     if (years && inputIQ) {
@@ -137,7 +137,7 @@ const RewardCalculator = ({
             <InputGroup>
               <Input
                 value={years}
-                placeholder="0"
+                placeholder="4"
                 onChange={e => updateYrs(e.target.valueAsNumber)}
                 type="number"
               />


### PR DESCRIPTION
# Calculator default value

_On the calculator for the IQ lock period, it should show four(4) years by default

fixes https://github.com/EveripediaNetwork/issues/issues/1139