### PR TITLE
fixes color issue apr info

### DIFF
--- a/src/components/cards/StakeCard.tsx
+++ b/src/components/cards/StakeCard.tsx
@@ -44,9 +44,11 @@ const StakeCard = (props: StakeCardProps) => {
                   Calculated based on the current IQ emissions rate (does not factor in future halvenings). \n 
                   IQ emissions halve annually on Nov. 1.
                 `}
-                bg="bodyBg"
                 placement="bottom"
-                padding="2"
+                color="grayText4"
+                rounded="lg"
+                p={5}
+                bg="tooltipBg"
               >
                 <Flex
                   display="inline-flex"


### PR DESCRIPTION
# fix color issue apr info

_When you hover on the APR card tooltip on the Stake page Braindao, the Hover text background is not too visible and not even readable, let's have a fix to ensure this is visible to the user and also readable to improve user experience


## Linked issues

fixes https://github.com/EveripediaNetwork/issues/issues/1207