### PR TITLE
Added $ prefix in IQ stats section

### DIFF
--- a/src/components/client/StatsPage.tsx
+++ b/src/components/client/StatsPage.tsx
@@ -105,8 +105,11 @@ const StatsPage = () => {
     { label: 'Reddit users', value: data.social?.reddit, icon: Reddit },
   ]
 
-  const STATS: Record<string, { items: Stat[]; valuePrefix?: string }> = {
-    IQ: { items: IQ },
+  const STATS: Record<
+    string,
+    { items: Stat[]; valuePrefix?: string; omitPrefix?: string }
+  > = {
+    IQ: { items: IQ, valuePrefix: '$', omitPrefix: 'IQ Locked' },
     'Onchain Liquidity': { items: liquidity, valuePrefix: '$' },
     'Circulating Supply': { items: circulatingSupply },
     Holders: { items: holders },
@@ -151,7 +154,12 @@ const StatsPage = () => {
                       fontSize={{ base: 'sm', md: 'md' }}
                       fontWeight="semibold"
                     >
-                      {showData(item.value, val.valuePrefix)}
+                      {showData(
+                        item.value,
+                        item.label === val.omitPrefix
+                          ? undefined
+                          : val.valuePrefix,
+                      )}
                     </Text>
                   </Flex>
                 ))}


### PR DESCRIPTION
# Added $  prefix to appropriate details in IQ section of Stats page 

Before :
![image](https://github.com/EveripediaNetwork/iq-ui/assets/75235148/240eefc0-f7e8-4cae-8d86-2aa595998ea1)

After :
![image](https://github.com/EveripediaNetwork/iq-ui/assets/75235148/39f89be3-8066-47b0-adef-baddbf4a4aaf)


## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/1328
