### PR TITLE
Update on the Voting Tab on BrainDAO Page

### DIFF
--- a/src/components/client/VotingPage.tsx
+++ b/src/components/client/VotingPage.tsx
@@ -176,23 +176,22 @@ const VotingPage = () => {
               _selected={{ color: 'brandText', borderColor: 'current' }}
               fontWeight="medium"
             >
-              Active votes
+              Old Votes
             </Tab>
             <Tab
               color="fadedText4"
               _selected={{ color: 'brandText', borderColor: 'current' }}
               fontWeight="medium"
             >
-              Old Votes
+              Active votes
             </Tab>
           </TabList>
-
           <TabPanels mt="4">
             <TabPanel p="0" w={{ base: 'full', lg: 'inherit' }}>
-              {activeVotes}
+              {oldVotes}
             </TabPanel>
             <TabPanel p="0" w={{ base: 'full', lg: 'inherit' }}>
-              {oldVotes}
+              {activeVotes}
             </TabPanel>
           </TabPanels>
         </Tabs>


### PR DESCRIPTION
# Update on the Voting Tab on BrainDAO Page

_The purpose of this feature is to display old voting data when there are no active votes available. By showcasing past voting records, users can gain insights into previous decisions, trends, and outcomes.


fixes https://github.com/EveripediaNetwork/issues/issues/1539