### PR TITLE
Treasury graph font

### DIFF
--- a/src/components/dashboard/TreasuryGraphTable.tsx
+++ b/src/components/dashboard/TreasuryGraphTable.tsx
@@ -64,7 +64,7 @@ export const TreasuryGraphTable = ({
   })
 
   const formatPieData = (data: TreasuryTokenType[], platformValue: number) => {
-    const result = data?.map(tok => ({
+    const result = data?.map((tok) => ({
       name: TOKENS[tok.id].name,
       value: (tok.raw_dollar / platformValue) * 100,
       amount: tok.raw_dollar,
@@ -132,7 +132,7 @@ export const TreasuryGraphTable = ({
                       <Td>
                         {typeof token.token === 'number'
                           ? Humanize.formatNumber(token.token, 2)
-                          : token.token.map(t => (
+                          : token.token.map((t) => (
                               <>
                                 <span>{`${formatValue(t.amount)} ${
                                   t.symbol

--- a/src/components/dashboard/TreasuryGraphTable.tsx
+++ b/src/components/dashboard/TreasuryGraphTable.tsx
@@ -51,9 +51,9 @@ export const TreasuryGraphTable = ({
   })
 
   const radius = useBreakpointValue({
-    base: { cx: 80, cy: 130 },
-    md: { cx: 110, cy: 180 },
-    lg: { cx: 100, cy: 170 },
+    base: { cx: 100, cy: 140 },
+    md: { cx: 120, cy: 210 },
+    lg: { cx: 120, cy: 190 },
     '2xl': { cx: 100, cy: 150 },
   })
   const spacing = useBreakpointValue({
@@ -64,7 +64,7 @@ export const TreasuryGraphTable = ({
   })
 
   const formatPieData = (data: TreasuryTokenType[], platformValue: number) => {
-    const result = data?.map((tok) => ({
+    const result = data?.map(tok => ({
       name: TOKENS[tok.id].name,
       value: (tok.raw_dollar / platformValue) * 100,
       amount: tok.raw_dollar,
@@ -132,7 +132,7 @@ export const TreasuryGraphTable = ({
                       <Td>
                         {typeof token.token === 'number'
                           ? Humanize.formatNumber(token.token, 2)
-                          : token.token.map((t) => (
+                          : token.token.map(t => (
                               <>
                                 <span>{`${formatValue(t.amount)} ${
                                   t.symbol

--- a/src/components/elements/PieChart/RenderActiveShape.tsx
+++ b/src/components/elements/PieChart/RenderActiveShape.tsx
@@ -30,10 +30,10 @@ const RenderActiveShape: PieActiveShape = (props: {
         x={cx}
         y={cy}
         dy={8}
-        fontSize="18"
+        fontSize="16"
         textAnchor="middle"
         fill={fill}
-        fontWeight="bold"
+        fontWeight="600"
       >
         {payload.name} {`(${(percent * 100).toFixed(1)}%)`}
       </text>

--- a/src/components/elements/PieChart/RenderActiveShape.tsx
+++ b/src/components/elements/PieChart/RenderActiveShape.tsx
@@ -33,7 +33,7 @@ const RenderActiveShape: PieActiveShape = (props: {
         fontSize="16"
         textAnchor="middle"
         fill={fill}
-        fontWeight="600"
+        fontWeight="semibold"
       >
         {payload.name} {`(${(percent * 100).toFixed(1)}%)`}
       </text>


### PR DESCRIPTION
# Treasury graph UI

_The UI of some text in the treasury page of the iq dashboard bleeds out of the graph and makes the UI bad _

Before 
![image](https://github.com/EveripediaNetwork/iq-ui/assets/75235148/b5a336c9-1660-4743-bfc5-345e817b04e9)
![image](https://github.com/EveripediaNetwork/iq-ui/assets/75235148/0892c05e-7de2-4556-84b4-560d5f3501d6)


After
![image](https://github.com/EveripediaNetwork/iq-ui/assets/75235148/0a8d7f33-6868-40ea-bea2-92071f42c139)
![image](https://github.com/EveripediaNetwork/iq-ui/assets/75235148/7effb0a6-6a04-4a3b-8836-c1679b5d9942)


## Linked issues
closes https://github.com/EveripediaNetwork/issues/issues/1587