### PR TITLE
Limit bridge transfer

### DIFF
--- a/src/components/client/BridgePage.tsx
+++ b/src/components/client/BridgePage.tsx
@@ -118,9 +118,7 @@ const BridgePage = () => {
 
     if (selectedToken.id === TokenId.IQ) {
       if (!inputAccount) {
-        showToast('Address cannot be empty', 'error')
-        setIsTransferring(false)
-        setIsTransferring(false)
+        handleError('Address cannot be empty')
         return
       }
       const { error } = await bridgeFromEthToEos(tokenInputAmount, inputAccount)

--- a/src/components/client/BridgePage.tsx
+++ b/src/components/client/BridgePage.tsx
@@ -37,7 +37,7 @@ import * as Humanize from 'humanize-plus'
 
 const PTOKEN_COMMISSION = 0.05
 
-const TRANSFER_LOWER_LIMIT = 10 // 
+const TRANSFER_LOWER_LIMIT = 10 //
 
 const BridgePage = () => {
   const authContext = useContext<AuthContextType>(UALContext)
@@ -68,20 +68,22 @@ const BridgePage = () => {
     pIQTokenBalance,
   } = useBridge()
 
+  const handleError = (errorMsg: string) => {
+    showToast(errorMsg, 'error')
+    setIsTransferring(false)
+    setIsTransferring(false)
+  }
+
   const handleTransfer = async () => {
     setIsTransferring(true)
 
     if (!tokenInputAmount || Number(tokenInputAmount) === 0) {
-      showToast('Amount cannot be empty', 'error')
-      setIsTransferring(false)
-      setIsTransferring(false)
+      handleError('Amount cannot be empty')
       return
     }
 
-    if ((Number(tokenInputAmount) * exchangeRate) < TRANSFER_LOWER_LIMIT) {
-      showToast('The minimum transfer amount is $20', 'error')
-      setIsTransferring(false)
-      setIsTransferring(false)
+    if (Number(tokenInputAmount) * exchangeRate < TRANSFER_LOWER_LIMIT) {
+      handleError('The minimum transfer amount is $20')
       return
     }
 

--- a/src/components/client/BridgePage.tsx
+++ b/src/components/client/BridgePage.tsx
@@ -37,6 +37,8 @@ import * as Humanize from 'humanize-plus'
 
 const PTOKEN_COMMISSION = 0.05
 
+const TRANSFER_LOWER_LIMIT = 10 // 
+
 const BridgePage = () => {
   const authContext = useContext<AuthContextType>(UALContext)
   const { activeUser, logout, showModal } = authContext
@@ -71,6 +73,13 @@ const BridgePage = () => {
 
     if (!tokenInputAmount || Number(tokenInputAmount) === 0) {
       showToast('Amount cannot be empty', 'error')
+      setIsTransferring(false)
+      setIsTransferring(false)
+      return
+    }
+
+    if ((Number(tokenInputAmount) * exchangeRate) < TRANSFER_LOWER_LIMIT) {
+      showToast('The minimum transfer amount is $20', 'error')
       setIsTransferring(false)
       setIsTransferring(false)
       return


### PR DESCRIPTION
# Limit the Bridge Transfer

_To ensure smooth transactions and cover the increased protocol fee (gas fee), we have set a minimum bridge transfer amount of $20. This will ensure that the necessary funds, including the $10 gas fee, are available to complete the transfer.

fixes https://github.com/EveripediaNetwork/issues/issues/1586