### PR TITLE
updates iq.wiki link

### DIFF
--- a/src/data/SidebarData.ts
+++ b/src/data/SidebarData.ts
@@ -77,7 +77,7 @@ export const EXTRA_ROUTES: SidebarItemType[] = [
   },
   {
     label: 'IQ.Wiki',
-    route: 'https://iq.wiki/',
+    route: 'https://iq.wiki/wiki/iqwiki',
     icon: BraindaoLogo,
     target: '_blank',
   },


### PR DESCRIPTION
# Proper linking of IQ.wiki

_ On the Dashboard page, there is an improper routing of the IQ.wiki, because currently, it is routing to the homepage of IQ.wiki which is providing enough information to the users, I would want to change to routing to https://iq.wiki/wiki/iqwiki where users can learn from the wiki page of IQ wiki.

fixes https://github.com/EveripediaNetwork/issues/issues/1645