### PR TITLE
proper linking of the braindao logo on the homepage

### DIFF
--- a/src/components/dashboard/sidebar.tsx
+++ b/src/components/dashboard/sidebar.tsx
@@ -32,7 +32,7 @@ export const Sidebar = (props: SidebarProps) => {
         borderBottom="solid 1px"
         borderColor={{ base: 'divider', md: 'transparent' }}
       >
-        <Link href="/" mx="auto">
+        <Link href="https://braindao.org/" target="_blank" mx="auto">
           <Image src={`/images/${logoSrc}`} />
         </Link>
         <LanguageSwitch ml="auto" display={{ md: 'none' }} />


### PR DESCRIPTION
# Linking the BrainDAO logo to the correct page

## How should this be tested?

1. Go to the brainDAO page
2. Click the brainDAO logo

## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/1691
