### PR TITLE
brand text correction

### DIFF
--- a/src/components/client/StatsPage.tsx
+++ b/src/components/client/StatsPage.tsx
@@ -92,8 +92,8 @@ const StatsPage = () => {
   )
 
   const apps = [
-    { label: 'IQ.Wiki articles', value: data.ep?.articles },
-    { label: 'IQ.Wiki Onchain Edits', value: data.ep?.edits },
+    { label: 'IQ.wiki articles', value: data.ep?.articles },
+    { label: 'IQ.wiki Onchain Edits', value: data.ep?.edits },
   ]
 
   const social = [

--- a/src/data/SidebarData.ts
+++ b/src/data/SidebarData.ts
@@ -77,7 +77,7 @@ export const EXTRA_ROUTES: SidebarItemType[] = [
     target: '_blank',
   },
   {
-    label: 'IQ.Wiki',
+    label: 'IQ.wiki',
     route: 'https://iq.wiki/wiki/iqwiki',
     icon: BraindaoLogo,
     target: '_blank',


### PR DESCRIPTION
# Brand text correction

Replaced "IQ.Wiki" to "IQ.wiki" for consistency and branding accuracy.

## Notes or observations

<img width="765" alt="image" src="https://github.com/EveripediaNetwork/iq-ui/assets/67792966/3582577f-efdc-4acc-8692-7b8126c8def7">

closes https://github.com/EveripediaNetwork/issues/issues/1732
