### PR TITLE
Improvement treasury table

### DIFF
--- a/src/components/dashboard/TreasuryGraphTable.tsx
+++ b/src/components/dashboard/TreasuryGraphTable.tsx
@@ -128,7 +128,7 @@ export const TreasuryGraphTable = ({
         my="8"
         gap={{ base: 2, '2xl': 16 }}
       >
-        <Box overflowX="auto" maxH="550px" >
+        <Box overflowX="auto" maxH="550px">
           <TableContainer
             border="solid 1px"
             borderColor="divider"
@@ -158,7 +158,7 @@ export const TreasuryGraphTable = ({
                 ? tokenDataToShow.map((token, i) => (
                     <Tr key={i} fontWeight="medium">
                       <Td>
-                        <Flex align="center" gap="14px">
+                        <Flex align="center" gap="4px">
                           {token.logo ? (
                             <Image src={token.logo} boxSize={7} />
                           ) : TOKENS[token.id].icon ? (
@@ -167,9 +167,10 @@ export const TreasuryGraphTable = ({
                             <Image src={TOKENS[token.id].image} width="30px" />
                           )}
                           <Text
+                            noOfLines={2}
                             whiteSpace='normal'
-                            minW={20}
-                            style={{ wordBreak: 'break-word' }}
+                            maxW={20}
+                            style={{ overflowWrap: 'normal' }}
                           >
                             {TOKENS[token.id].name}
                           </Text>
@@ -194,8 +195,9 @@ export const TreasuryGraphTable = ({
                       </Td>
                       <Td textAlign="center">
                         {`$${formatValue(token.raw_dollar)} `}
-                        <span style={{fontSize: "smaller"}}>
-                          ({Humanize.formatNumber(
+                        <span style={{ fontSize: 'smaller' }}>
+                          (
+                          {Humanize.formatNumber(
                             (token.raw_dollar / accountValue) * 100,
                             2,
                           )}

--- a/src/components/dashboard/TreasuryGraphTable.tsx
+++ b/src/components/dashboard/TreasuryGraphTable.tsx
@@ -129,103 +129,109 @@ export const TreasuryGraphTable = ({
         mb="16"
         gap={{ base: 2, '2xl': 16 }}
       >
-          <TableContainer
-            border="solid 1px"
-            borderColor="divider"
-            rounded="lg"
-            fontSize="sm"
-            overflowY="scroll" 
-            maxH="550px"
+        <TableContainer
+          border="solid 1px"
+          borderColor="divider"
+          rounded="lg"
+          fontSize="sm"
+          overflowY="scroll"
+          maxH="550px"
+        >
+          <Table
+            w={{
+              base: 'full',
+              lg: tokenData.length > 0 ? 'full' : 600,
+              '2xl': 630,
+            }}
           >
-            <Table
-              w={{
-                base: 'full',
-                lg: tokenData.length > 0 ? 'full' : 600,
-                '2xl': 630,
-              }}
+            <Thead
+              border="none"
+              bg="cardBg"
+              position="sticky"
+              top={0}
+              zIndex="docked"
             >
-              <Thead border="none" bg="cardBg" position="sticky" top={0} zIndex="docked">
-                {TOKEN_KEYS.map((key, i, arr) => (
-                  <Td
-                    whiteSpace="nowrap"
-                    key={key}
-                    fontWeight="medium"
-                    textAlign={i === arr.length - 1 ? 'center' : 'initial'}
-                  >
-                    {key}
-                  </Td>
+              {TOKEN_KEYS.map((key, i, arr) => (
+                <Td
+                  whiteSpace="nowrap"
+                  key={key}
+                  fontWeight="medium"
+                  textAlign={i === arr.length - 1 ? 'center' : 'initial'}
+                >
+                  {key}
+                </Td>
+              ))}
+            </Thead>
+            {tokenDataToShow.length > 0
+              ? tokenDataToShow.map((token, i) => (
+                  <Tr key={i} fontWeight="medium">
+                    <Td>
+                      <Flex align="center" gap="4px">
+                        {token.logo ? (
+                          <Image src={token.logo} boxSize={7} />
+                        ) : TOKENS[token.id].icon ? (
+                          <Icon as={TOKENS[token.id].icon} boxSize={7} />
+                        ) : (
+                          <Image src={TOKENS[token.id].image} width="30px" />
+                        )}
+                        <Text
+                          noOfLines={2}
+                          whiteSpace='normal'
+                          maxW={20}
+                          style={{ overflowWrap: 'normal' }}
+                        >
+                          {TOKENS[token.id].name}
+                        </Text>
+                      </Flex>
+                    </Td>
+                    <Td>
+                      {typeof token.token === 'number'
+                        ? Humanize.compactInteger(token.token, 1)
+                        : token.token.map((t) => (
+                            <>
+                              <span>{`${formatValue(t.amount)} ${
+                                t.symbol
+                              }`}</span>
+                              <br />
+                            </>
+                          ))}
+                    </Td>
+                    <Td textAlign="center">
+                      {token.yield
+                        ? `${Humanize.formatNumber(token.yield, 2)}%`
+                        : '-'}
+                    </Td>
+                    <Td textAlign="center">
+                      {`$${formatValue(token.raw_dollar)} `}
+                      <span style={{ fontSize: 'smaller' }}>
+                        (
+                        {Humanize.formatNumber(
+                          (token.raw_dollar / accountValue) * 100,
+                          2,
+                        )}
+                        %)
+                      </span>
+                    </Td>
+                  </Tr>
+                ))
+              : [1, 2, 3, 4, 5, 6].map((_, index) => (
+                  <Tr key={index} fontWeight="medium">
+                    <Td>
+                      <SkeletonText noOfLines={1} />
+                    </Td>
+                    <Td>
+                      <SkeletonText noOfLines={1} />
+                    </Td>
+                    <Td textAlign="center">
+                      <SkeletonText noOfLines={1} />
+                    </Td>
+                    <Td textAlign="center">
+                      <SkeletonText noOfLines={1} />
+                    </Td>
+                  </Tr>
                 ))}
-              </Thead>
-              {tokenDataToShow.length > 0
-                ? tokenDataToShow.map((token, i) => (
-                    <Tr key={i} fontWeight="medium">
-                      <Td>
-                        <Flex align="center" gap="4px">
-                          {token.logo ? (
-                            <Image src={token.logo} boxSize={7} />
-                          ) : TOKENS[token.id].icon ? (
-                            <Icon as={TOKENS[token.id].icon} boxSize={7} />
-                          ) : (
-                            <Image src={TOKENS[token.id].image} width="30px" />
-                          )}
-                          <Text
-                            noOfLines={2}
-                            whiteSpace='normal'
-                            maxW={20}
-                            style={{ overflowWrap: 'normal' }}
-                          >
-                            {TOKENS[token.id].name}
-                          </Text>
-                        </Flex>
-                      </Td>
-                      <Td>
-                        {typeof token.token === 'number'
-                          ? Humanize.compactInteger(token.token, 1)
-                          : token.token.map((t) => (
-                              <>
-                                <span>{`${formatValue(t.amount)} ${
-                                  t.symbol
-                                }`}</span>
-                                <br />
-                              </>
-                            ))}
-                      </Td>
-                      <Td textAlign="center">
-                        {token.yield
-                          ? `${Humanize.formatNumber(token.yield, 2)}%`
-                          : '-'}
-                      </Td>
-                      <Td textAlign="center">
-                        {`$${formatValue(token.raw_dollar)} `}
-                        <span style={{ fontSize: 'smaller' }}>
-                          (
-                          {Humanize.formatNumber(
-                            (token.raw_dollar / accountValue) * 100,
-                            2,
-                          )}
-                          %)
-                        </span>
-                      </Td>
-                    </Tr>
-                  ))
-                : [1, 2, 3, 4, 5, 6].map((_, index) => (
-                    <Tr key={index} fontWeight="medium">
-                      <Td>
-                        <SkeletonText noOfLines={1} />
-                      </Td>
-                      <Td>
-                        <SkeletonText noOfLines={1} />
-                      </Td>
-                      <Td textAlign="center">
-                        <SkeletonText noOfLines={1} />
-                      </Td>
-                      <Td textAlign="center">
-                        <SkeletonText noOfLines={1} />
-                      </Td>
-                    </Tr>
-                  ))}
-            </Table>
-          </TableContainer>
+          </Table>
+        </TableContainer>
         <Box
           display="flex"
           mt={{ lg: -2 }}

--- a/src/components/dashboard/TreasuryGraphTable.tsx
+++ b/src/components/dashboard/TreasuryGraphTable.tsx
@@ -58,7 +58,7 @@ export const TreasuryGraphTable = ({
   const boxSize = useBreakpointValue({
     base: { cx: 300, cy: 300 },
     md: { cx: 519, cy: 519 },
-    lg: { cx: 500, cy: 450 },
+    lg: { cx: 460, cy: 450 },
     '2xl': { cx: 380, cy: 400 },
   })
 
@@ -72,7 +72,7 @@ export const TreasuryGraphTable = ({
     base: { cx: 150, cy: 140 },
     md: { cx: 230, cy: 240 },
     lg: { cx: 250, cy: 210 },
-    '2xl': { cx: 210, cy: 210 },
+    '2xl': { cx: 200, cy: 210 },
   })
 
   const formatPieData = (data: TreasuryTokenType[], platformValue: number) => {
@@ -126,10 +126,15 @@ export const TreasuryGraphTable = ({
       <Flex
         direction={{ base: 'column', lg: 'row' }}
         my="8"
-        gap={{ base: 10, '2xl': 18 }}
+        gap={{ base: 2, '2xl': 16 }}
       >
-        <Box overflowX="auto" maxH="550px">
-          <TableContainer border="solid 1px" borderColor="divider" rounded="lg">
+        <Box overflowX="auto" maxH="550px" >
+          <TableContainer
+            border="solid 1px"
+            borderColor="divider"
+            rounded="lg"
+            fontSize="sm"
+          >
             <Table
               w={{
                 base: 'full',
@@ -153,7 +158,7 @@ export const TreasuryGraphTable = ({
                 ? tokenDataToShow.map((token, i) => (
                     <Tr key={i} fontWeight="medium">
                       <Td>
-                        <Flex align="center" gap="18px">
+                        <Flex align="center" gap="14px">
                           {token.logo ? (
                             <Image src={token.logo} boxSize={7} />
                           ) : TOKENS[token.id].icon ? (
@@ -161,12 +166,18 @@ export const TreasuryGraphTable = ({
                           ) : (
                             <Image src={TOKENS[token.id].image} width="30px" />
                           )}
-                          <Text fontSize="sm">{TOKENS[token.id].name}</Text>
+                          <Text
+                            whiteSpace='normal'
+                            minW={20}
+                            style={{ wordBreak: 'break-word' }}
+                          >
+                            {TOKENS[token.id].name}
+                          </Text>
                         </Flex>
                       </Td>
                       <Td>
                         {typeof token.token === 'number'
-                          ? Humanize.formatNumber(token.token, 2)
+                          ? Humanize.compactInteger(token.token, 1)
                           : token.token.map((t) => (
                               <>
                                 <span>{`${formatValue(t.amount)} ${
@@ -182,12 +193,14 @@ export const TreasuryGraphTable = ({
                           : '-'}
                       </Td>
                       <Td textAlign="center">
-                        ${formatValue(token.raw_dollar)} (
-                        {Humanize.formatNumber(
-                          (token.raw_dollar / accountValue) * 100,
-                          2,
-                        )}
-                        %)
+                        {`$${formatValue(token.raw_dollar)} `}
+                        <span style={{fontSize: "smaller"}}>
+                          ({Humanize.formatNumber(
+                            (token.raw_dollar / accountValue) * 100,
+                            2,
+                          )}
+                          %)
+                        </span>
                       </Td>
                     </Tr>
                   ))

--- a/src/components/dashboard/TreasuryGraphTable.tsx
+++ b/src/components/dashboard/TreasuryGraphTable.tsx
@@ -125,7 +125,8 @@ export const TreasuryGraphTable = ({
       />
       <Flex
         direction={{ base: 'column', lg: 'row' }}
-        my="8"
+        mt="4"
+        mb="16"
         gap={{ base: 2, '2xl': 16 }}
       >
         <Box overflowX="auto" maxH="550px">

--- a/src/components/dashboard/TreasuryGraphTable.tsx
+++ b/src/components/dashboard/TreasuryGraphTable.tsx
@@ -129,12 +129,13 @@ export const TreasuryGraphTable = ({
         mb="16"
         gap={{ base: 2, '2xl': 16 }}
       >
-        <Box overflowX="auto" maxH="550px">
           <TableContainer
             border="solid 1px"
             borderColor="divider"
             rounded="lg"
             fontSize="sm"
+            overflowY="scroll" 
+            maxH="550px"
           >
             <Table
               w={{
@@ -143,7 +144,7 @@ export const TreasuryGraphTable = ({
                 '2xl': 630,
               }}
             >
-              <Thead border="none" bg="cardBg">
+              <Thead border="none" bg="cardBg" position="sticky" top={0} zIndex="docked">
                 {TOKEN_KEYS.map((key, i, arr) => (
                   <Td
                     whiteSpace="nowrap"
@@ -225,7 +226,6 @@ export const TreasuryGraphTable = ({
                   ))}
             </Table>
           </TableContainer>
-        </Box>
         <Box
           display="flex"
           mt={{ lg: -2 }}

--- a/src/utils/LockOverviewUtils.ts
+++ b/src/utils/LockOverviewUtils.ts
@@ -119,8 +119,8 @@ export const formatValue = (value: number) => {
   if (value !== undefined) {
     const valueToString = value.toString()
     return valueToString.length > 6
-      ? Humanize.compactInteger(value, 2)
-      : Humanize.formatNumber(value, 2)
+      ? Humanize.compactInteger(value, 1)
+      : Humanize.formatNumber(value, 1)
   }
   return 0
 }


### PR DESCRIPTION
# Made improvements to the treasury table to make all the columns visible and prevent side scrolling.

![image](https://github.com/EveripediaNetwork/iq-ui/assets/58448956/04d08feb-9f0d-4031-9f6b-1fbb9bdd8fc0)


## Linked issues

closes #1738, closes #1738, closes https://github.com/EveripediaNetwork/issues/issues/1738