### PR TITLE
Reduce api calls

### DIFF
--- a/src/components/dashboard/IQButton.tsx
+++ b/src/components/dashboard/IQButton.tsx
@@ -1,29 +1,14 @@
 import { Box, Button, Tooltip, Spinner, ButtonProps } from '@chakra-ui/react'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { addToken } from '@/utils/add-new-token'
 import Image from 'next/image'
 import * as Humanize from 'humanize-plus'
-import axios from 'axios'
+import { useGetIqPriceQuery } from '@/services/iqPrice'
 
 export const IQButton = (props: ButtonProps) => {
   const SIG_FIGS = 4
-  const [price, setPrice] = useState(0)
-  const [isLoading, setIsLoading] = useState(true)
-  useEffect(() => {
-    ;(async () => {
-      try {
-        const res = await axios.get(
-          'https://api.coingecko.com/api/v3/coins/everipedia/market_chart?vs_currency=usd&days=1',
-        )
-        const { prices } = res.data
-        setPrice(prices[prices.length - 1][1])
-        setIsLoading(false)
-      } catch (error) {
-        console.error(error)
-        setIsLoading(true)
-      }
-    })()
-  }, [price])
+  const { data, isLoading, error } = useGetIqPriceQuery()
+
   return (
     <>
       <Button
@@ -58,13 +43,18 @@ export const IQButton = (props: ButtonProps) => {
               width={25}
               height={21}
             />
-            {isLoading ? (
+            {error ? (
+              <>Oh no, there was an error</>
+            ) : isLoading ? (
               <Spinner size="xs" color="brandText" />
-            ) : (
+            ) : data ? (
               <Box
                 fontSize={{ base: 'xs', md: 'inherit' }}
-              >{`${Humanize.formatNumber(price, SIG_FIGS)}`}</Box>
-            )}
+              >{`${Humanize.formatNumber(
+                data?.everipedia?.usd,
+                SIG_FIGS,
+              )}`}</Box>
+            ) : null}
           </Box>
         </Tooltip>
       </Button>

--- a/src/components/dashboard/TreasuryGraphTable.tsx
+++ b/src/components/dashboard/TreasuryGraphTable.tsx
@@ -17,7 +17,7 @@ import {
   Image,
   Text,
 } from '@chakra-ui/react'
-import React, { useCallback, useState, useEffect } from 'react'
+import React, { useCallback, useState, useEffect, useRef } from 'react'
 import {
   SortAndSumTokensValue,
   calculateYield,
@@ -47,6 +47,7 @@ export const TreasuryGraphTable = ({
   const [pieData, setPieData] = useState<ChartDataType[]>([])
   const [accountValue, setAccountValue] = useState<number>(0)
   const { colorMode } = useColorMode()
+  const isTokenFetched = useRef(false)
 
   const onPieEnter = useCallback<OnPieEnter>(
     (_, index) => {
@@ -84,36 +85,38 @@ export const TreasuryGraphTable = ({
     setPieData(result)
   }
 
+  const getTokens = useCallback(async () => {
+    const treasuryTokens = await getTreasuryDetails()
+    const updatedTreasuryTokens = [
+      ...treasuryTokens,
+      {
+        id: 'HiIQ',
+        token: userTotalIQLocked,
+        raw_dollar: userTotalIQLocked * rate,
+        contractAddress: config.treasuryHiIQAddress,
+      },
+    ]
+    const { sortedTreasuryDetails, totalAccountValue } =
+      await SortAndSumTokensValue(updatedTreasuryTokens)
+    const treasuryValuePlusYield = sortedTreasuryDetails.map(async (token) => ({
+      ...token,
+      yield: await calculateYield(token, totalHiiqSupply),
+    }))
+    const resolvedTreasuryValuePlusYield = await Promise.all(
+      treasuryValuePlusYield,
+    )
+    setAccountValue(totalAccountValue)
+    setTreasuryValue(totalAccountValue)
+    formatPieData(resolvedTreasuryValuePlusYield, totalAccountValue)
+    setTokenData(resolvedTreasuryValuePlusYield)
+    setTokenDataToShow(resolvedTreasuryValuePlusYield)
+  }, [])
+
   useEffect(() => {
-    const getTokens = async () => {
-      const treasuryTokens = await getTreasuryDetails()
-      const updatedTreasuryTokens = [
-        ...treasuryTokens,
-        {
-          id: 'HiIQ',
-          token: userTotalIQLocked,
-          raw_dollar: userTotalIQLocked * rate,
-          contractAddress: config.treasuryHiIQAddress,
-        },
-      ]
-      const { sortedTreasuryDetails, totalAccountValue } =
-        await SortAndSumTokensValue(updatedTreasuryTokens)
-      const treasuryValuePlusYield = sortedTreasuryDetails.map(
-        async (token) => ({
-          ...token,
-          yield: await calculateYield(token, totalHiiqSupply),
-        }),
-      )
-      const resolvedTreasuryValuePlusYield = await Promise.all(
-        treasuryValuePlusYield,
-      )
-      setAccountValue(totalAccountValue)
-      setTreasuryValue(totalAccountValue)
-      formatPieData(resolvedTreasuryValuePlusYield, totalAccountValue)
-      setTokenData(resolvedTreasuryValuePlusYield)
-      setTokenDataToShow(resolvedTreasuryValuePlusYield)
-    }
+    if(!isTokenFetched.current) {
+      isTokenFetched.current = true
     getTokens()
+    }
   }, [rate])
 
   return (

--- a/src/components/dashboard/TreasuryGraphTable.tsx
+++ b/src/components/dashboard/TreasuryGraphTable.tsx
@@ -113,9 +113,9 @@ export const TreasuryGraphTable = ({
   }, [])
 
   useEffect(() => {
-    if(!isTokenFetched.current) {
+    if (!isTokenFetched.current) {
       isTokenFetched.current = true
-    getTokens()
+      getTokens()
     }
   }, [rate])
 

--- a/src/services/iqPrice/index.ts
+++ b/src/services/iqPrice/index.ts
@@ -1,0 +1,31 @@
+import { EP_COINGECKO_URL } from '@/data/LockConstants'
+import { HYDRATE } from 'next-redux-wrapper'
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+
+export const iqPriceApi = createApi({
+  reducerPath: 'iqPriceApi',
+  extractRehydrationInfo(action, { reducerPath }) {
+    if (action.type === HYDRATE) {
+      return action.payload[reducerPath]
+    }
+    return null
+  },
+  baseQuery: fetchBaseQuery({
+    baseUrl: EP_COINGECKO_URL,
+  }),
+  refetchOnMountOrArgChange: 30,
+  refetchOnFocus: true,
+  endpoints: (builder) => ({
+    getIqPrice: builder.query<
+      {
+        [key: string]: {
+          usd: number
+        }
+      },
+      void
+    >({
+      query: () => '',
+    }),
+  }),
+})
+export const { useGetIqPriceQuery } = iqPriceApi

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -3,6 +3,7 @@ import { ensReducer, gaugesReducer, nftFarmReducer } from '@/store/slices'
 import { stakeApi } from '@/services/stake'
 import { IQHoldersApi } from '@/services/holders'
 import { treasuryApi } from '@/services/treasury'
+import { iqPriceApi } from '@/services/iqPrice'
 
 export const store = configureStore({
   reducer: {
@@ -12,12 +13,14 @@ export const store = configureStore({
     [stakeApi.reducerPath]: stakeApi.reducer,
     [IQHoldersApi.reducerPath]: IQHoldersApi.reducer,
     [treasuryApi.reducerPath]: treasuryApi.reducer,
+    [iqPriceApi.reducerPath]: iqPriceApi.reducer,
   },
   middleware: (gDM) =>
     gDM({ serializableCheck: true })
       .concat(stakeApi.middleware)
       .concat(IQHoldersApi.middleware)
-      .concat(treasuryApi.middleware),
+      .concat(treasuryApi.middleware)
+      .concat(iqPriceApi.middleware),
 })
 
 export type RootState = ReturnType<typeof store.getState>

--- a/src/utils/treasury-utils.ts
+++ b/src/utils/treasury-utils.ts
@@ -177,7 +177,6 @@ export const calculateYield = async (
   }
   if (typeof token.token !== 'number' && token.id === 'convex_cvxfxs_staked') {
     //TODO: Use convex contracts for on chain APR calculation
-    // const cvxFXSApi = await fetchFraxPairApr('cvxFXS')
     return null
   }
   if (token.id === 'HiIQ') {


### PR DESCRIPTION
# Reduce API calls to CG and Frax

- Reduce the number of API calls to coingecko for iq price
- Prevent treasury page useEffect from running twice 

### Treasury Page
- Before

![image](https://github.com/EveripediaNetwork/iq-ui/assets/58448956/89b37ce4-d461-45d7-8a73-58b61ee948fb)

- After

![image](https://github.com/EveripediaNetwork/iq-ui/assets/58448956/39d1a3ec-6c19-4ce8-8a33-536a3d40caa8)




## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/1895
