### PR TITLE
Fix Staking bug

### DIFF
--- a/src/components/client/StakePage.tsx
+++ b/src/components/client/StakePage.tsx
@@ -18,6 +18,7 @@ import {
   Tab,
   chakra,
   Icon,
+  Button,
 } from '@chakra-ui/react'
 import React, { useState, useEffect, useCallback } from 'react'
 import { RiQuestionLine } from 'react-icons/ri'
@@ -59,7 +60,7 @@ const StakePage = () => {
     setTrxHash(undefined)
   }
   const { showToast } = useReusableToast()
-  const { lockEndDate } = useLockEnd()
+  const { lockEndDate, refetchUserLockEndDate } = useLockEnd()
 
   useEffect(() => {
     if (trxHash && data) {
@@ -229,7 +230,22 @@ const StakePage = () => {
                   </TabPanel>
                   <TabPanel p={0} mt={7}>
                     <VStack rowGap={6}>
-                      <IncreaseLockTime />
+                      {lockEndDate ? (
+                        <IncreaseLockTime />
+                      ) : (
+                        <VStack>
+                          <Text
+                            fontSize="sm"
+                            fontWeight="normal"
+                            color="fadedText"
+                          >
+                            Error fetching lock end date
+                          </Text>
+                          <Button size={'sm'} onClick={refetchUserLockEndDate}>
+                            Retry
+                          </Button>
+                        </VStack>
+                      )}
                     </VStack>
                   </TabPanel>
                 </TabPanels>

--- a/src/components/client/StakePage.tsx
+++ b/src/components/client/StakePage.tsx
@@ -230,7 +230,7 @@ const StakePage = () => {
                   </TabPanel>
                   <TabPanel p={0} mt={7}>
                     <VStack rowGap={6}>
-                      {lockEndDate ? (
+                      {lockEndDate !== undefined && lockEndDate !== null ? (
                         <IncreaseLockTime />
                       ) : (
                         <VStack>

--- a/src/hooks/useLockEnd.ts
+++ b/src/hooks/useLockEnd.ts
@@ -4,11 +4,14 @@ import { useLockOverview } from './useLockOverview'
 
 export const useLockEnd = () => {
   const [lockEndDate, setLockEndDate] = useState<Date>()
-  const { userLockendDate } = useLockOverview()
+  const { userLockendDate, refetchUserLockEndDate } = useLockOverview()
   useEffect(() => {
-    const value = getUserLockEndDate(userLockendDate?.toString() ?? '')
-    setLockEndDate(value)
+    setLockEndDate(
+      userLockendDate !== undefined
+        ? getUserLockEndDate(userLockendDate.toString())
+        : undefined,
+    )
   }, [userLockendDate])
 
-  return { lockEndDate } as const
+  return { lockEndDate, refetchUserLockEndDate } as const
 }

--- a/src/hooks/useLockEnd.ts
+++ b/src/hooks/useLockEnd.ts
@@ -1,18 +1,16 @@
-import { useCallback } from 'react'
-import { useLockOverview } from './useLockOverview'
 import { getUserLockEndDate } from '@/utils/LockOverviewUtils'
+import { useEffect, useState } from 'react'
+import { useLockOverview } from './useLockOverview'
 
 export const useLockEnd = () => {
+  const [lockEndDate, setLockEndDate] = useState<Date>()
   const { userLockendDate, refetchUserLockEndDate } = useLockOverview()
-
-  const lockEndDate =
-    userLockendDate !== undefined
-      ? getUserLockEndDate(userLockendDate.toString())
-      : undefined
-
-  const memoizedRefetch = useCallback(() => {
-    refetchUserLockEndDate()
-  }, [userLockendDate, refetchUserLockEndDate])
-
-  return { lockEndDate, refetchUserLockEndDate: memoizedRefetch } as const
+  useEffect(() => {
+    setLockEndDate(
+      userLockendDate !== undefined
+        ? getUserLockEndDate(userLockendDate.toString())
+        : undefined,
+    )
+  }, [userLockendDate])
+  return { lockEndDate, refetchUserLockEndDate } as const
 }

--- a/src/hooks/useLockEnd.ts
+++ b/src/hooks/useLockEnd.ts
@@ -1,17 +1,18 @@
-import { getUserLockEndDate } from '@/utils/LockOverviewUtils'
-import { useEffect, useState } from 'react'
+import { useCallback } from 'react'
 import { useLockOverview } from './useLockOverview'
+import { getUserLockEndDate } from '@/utils/LockOverviewUtils'
 
 export const useLockEnd = () => {
-  const [lockEndDate, setLockEndDate] = useState<Date>()
   const { userLockendDate, refetchUserLockEndDate } = useLockOverview()
-  useEffect(() => {
-    setLockEndDate(
-      userLockendDate !== undefined
-        ? getUserLockEndDate(userLockendDate.toString())
-        : undefined,
-    )
-  }, [userLockendDate])
 
-  return { lockEndDate, refetchUserLockEndDate } as const
+  const lockEndDate =
+    userLockendDate !== undefined
+      ? getUserLockEndDate(userLockendDate.toString())
+      : undefined
+
+  const memoizedRefetch = useCallback(() => {
+    refetchUserLockEndDate()
+  }, [userLockendDate, refetchUserLockEndDate])
+
+  return { lockEndDate, refetchUserLockEndDate: memoizedRefetch } as const
 }


### PR DESCRIPTION
# Fixes staking UI bug that caused locking duration to be shown for more than 4 years


- Error caused due to `userLockendDate` API failing
![Screenshot from 2024-01-29 09-52-43](https://github.com/EveripediaNetwork/iq-ui/assets/58448956/0ce8b5e0-8bf3-402a-8787-45e621f2821c)

- Refactor useLockend to prevent defaulting to 0 on API error
- Disable UI on error and add option to refetch lockend
![Screenshot from 2024-01-29 12-45-08](https://github.com/EveripediaNetwork/iq-ui/assets/58448956/a1519ec6-9ac6-4af7-95d0-045f6ec23375)

## How should this be tested?

1. userLockend can be manually set to undefined for testing


## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/2139
