### PR TITLE
Fix IQ balance not showing in stake page

### DIFF
--- a/src/hooks/useErc20.ts
+++ b/src/hooks/useErc20.ts
@@ -1,12 +1,15 @@
 import IQABI from '@/abis/IQABI.abi'
 import config from '@/config'
 import { formatEther } from 'viem'
-import { useAccount, useReadContract, useBalance } from 'wagmi'
+import { useAccount, useReadContract } from 'wagmi'
 
 export const useErc20 = () => {
   const { address } = useAccount()
-  const { data: erc20Balance, refetch: refetchErc20Balance } = useBalance({
-    address: address as `0x${string}`,
+  const { data: erc20Balance, refetch: refetchErc20Balance } = useReadContract({
+    address: config.iqAddress as `0x${string}`,
+    abi: IQABI,
+    functionName: 'balanceOf',
+    args: [address as `0x${string}`],
   })
 
   const { data: totalValueLocked } = useReadContract({
@@ -20,7 +23,7 @@ export const useErc20 = () => {
     if (address) {
       refetchErc20Balance()
     }
-    return erc20Balance?.value ?? BigInt(0)
+    return erc20Balance ?? BigInt(0)
   }
   const tvl = () => {
     if (totalValueLocked) {


### PR DESCRIPTION
# Fix IQ balance not showing in stake page

- Wagmi v2 deprecated `useBalance` for non-native tokens

![image](https://github.com/EveripediaNetwork/iq-ui/assets/58448956/c6cdebfe-fe2a-40c7-8886-bcf1d2689fec)


## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/2608
