### PR TITLE
Treasury graph fix

### DIFF
--- a/src/components/client/TreasuryPage.tsx
+++ b/src/components/client/TreasuryPage.tsx
@@ -22,7 +22,7 @@ import { CUSTOM_GRAPH_PERIODS, StakeGraphPeriod } from '@/data/dashboard-data'
 import { getDateRange } from '@/utils/dashboard-utils'
 import { useGetTreasuryValueQuery } from '@/services/treasury/graphql'
 import GraphPeriodButton from '../dashboard/GraphPeriodButton'
-import { EmblaOptionsType } from 'embla-carousel-react'
+import type { EmblaOptionsType } from 'embla-carousel-react'
 import Autoplay from 'embla-carousel-autoplay'
 
 const TreasuryPage: NextPage = () => {

--- a/src/components/dashboard/GraphComponent.tsx
+++ b/src/components/dashboard/GraphComponent.tsx
@@ -8,14 +8,14 @@ import {
   Link,
 } from '@chakra-ui/react'
 import { Icon } from '@chakra-ui/react'
-import React, { ReactNode } from 'react'
+import React, { type ReactNode } from 'react'
 import { BraindaoLogo } from '../braindao-logo'
 import { Area, AreaChart, ResponsiveContainer, Tooltip, YAxis } from 'recharts'
 import CustomTooltip from './CustomTooltip'
 import * as Humanize from 'humanize-plus'
 import GraphLine from './GraphLine'
 import GraphPeriodWrapper from './GraphPeriodWrapper'
-import { Dict } from '@chakra-ui/utils'
+import type { Dict } from '@chakra-ui/utils'
 import NextLink from 'next/link'
 
 const GraphComponent = ({

--- a/src/components/dashboard/GraphDetails.tsx
+++ b/src/components/dashboard/GraphDetails.tsx
@@ -23,7 +23,7 @@ import {
   StakeGraphPeriod,
 } from '@/data/dashboard-data'
 import { getDateRange, renderPercentChange } from '@/utils/dashboard-utils'
-import {
+import type {
   ChartDataType,
   OnPieEnter,
   ChartConstantNonTreasury,
@@ -35,7 +35,6 @@ import GraphPeriodButton from '@/components/dashboard/GraphPeriodButton'
 import GraphComponent from '@/components/dashboard/GraphComponent'
 import TokenSupplyData from '@/components/dashboard/TokenSupplyData'
 import { getNumberOfHiIQHolders } from '@/utils/LockOverviewUtils'
-
 import { useGetStakeValueQuery } from '@/services/stake'
 import { useGetTreasuryValueQuery } from '@/services/treasury/graphql'
 import useBoxSizes from '@/utils/graph-utils'
@@ -49,10 +48,25 @@ export const DashboardGraphData = () => {
   const [colorData, setColorData] = useState<ChartConstantNonTreasury>({})
   const [activeIndex, setActiveIndex] = useState(0)
 
-  const { value, getRadioProps } = useRadioGroup({
-    defaultValue: GraphPeriod.MONTH,
+  const [treasuryGraphPeriod, _setTreasuryGraphPeriod] = useState(
+    StakeGraphPeriod['30DAYS'],
+  )
+
+  const {
+    value,
+    getRadioProps: getTreasuryRadioProps,
+    getRootProps: getTreasuryRootProps,
+  } = useRadioGroup({
+    defaultValue: StakeGraphPeriod['30DAYS'],
   })
 
+  const { startDate: treasuryStartDate, endDate: treasuryEndDate } =
+    getDateRange(treasuryGraphPeriod)
+
+  const { data: treasuryData } = useGetTreasuryValueQuery({
+    startDate: treasuryStartDate,
+    endDate: treasuryEndDate,
+  })
   const {
     value: stakeValue,
     getRadioProps: getStakeRadioProps,
@@ -62,11 +76,6 @@ export const DashboardGraphData = () => {
   })
 
   const { startDate, endDate } = getDateRange(stakeValue as string)
-
-  const { data: treasuryData } = useGetTreasuryValueQuery({
-    startDate,
-    endDate,
-  })
 
   const { data: stakeData } = useGetStakeValueQuery({
     startDate,
@@ -107,10 +116,9 @@ export const DashboardGraphData = () => {
     [setActiveIndex],
   )
 
-  const { getRadioProps: getTokenRadioProps, getRootProps: getTokenRootProps } =
-    useRadioGroup({
-      defaultValue: StakeGraphPeriod['30DAYS'],
-    })
+  const { getRadioProps: getTokenRadioProps } = useRadioGroup({
+    defaultValue: GraphPeriod.MONTH,
+  })
 
   const { boxSize, spacing, radius } = useBoxSizes()
 
@@ -179,7 +187,7 @@ export const DashboardGraphData = () => {
                 <GraphPeriodButton
                   key={btn.period}
                   label={btn.label}
-                  {...getRadioProps({ value: btn.period })}
+                  {...getTokenRadioProps({ value: btn.period })}
                 />
               )
             })}
@@ -293,7 +301,7 @@ export const DashboardGraphData = () => {
           <GraphComponent
             graphTitle="BrainDAO Treasury"
             graphData={treasuryGraphData}
-            getRootProps={getTokenRootProps}
+            getRootProps={getTreasuryRootProps}
             graphCurrentValue={treasuryValue}
             areaGraph={false}
             height={200}
@@ -308,7 +316,7 @@ export const DashboardGraphData = () => {
                     btn.period === StakeGraphPeriod['1Y'] ||
                     btn.period === StakeGraphPeriod.ALL
                   }
-                  {...getTokenRadioProps({ value: btn.period })}
+                  {...getTreasuryRadioProps({ value: btn.period })}
                 />
               )
             })}

--- a/src/services/treasury/graphql/index.ts
+++ b/src/services/treasury/graphql/index.ts
@@ -3,7 +3,7 @@ import { HYDRATE } from 'next-redux-wrapper'
 import { graphqlRequestBaseQuery } from '@rtk-query/graphql-request-base-query'
 import config from '@/config'
 import { DAILY_TREASURY } from '../queries'
-import { QueryParams } from '@/types/service'
+import type { QueryParams } from '@/types/service'
 
 type GetTreasuryResponse = {
   dailyTreasury: { created: string; totalValue: string }[]


### PR DESCRIPTION
# Braindao Treasury Graph Fix

This PR:
1. Fixes the Braindao Treasury graph unresponsive to button clicks on date changes
2. Also addresses the "IQ Staked Over Time" buttons controlling both the "IQ Staked Over Time" and the "Braindao 
Treasury" Graphs.

<h3> Before </h3> 

https://github.com/user-attachments/assets/1bcd275a-04c9-4750-8202-ada4e36f4707

<h3> After </h3>

https://github.com/user-attachments/assets/e56be251-c270-46ab-a328-c9a0431cf6b8





## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/2931
