### PR TITLE
Set hiIQ holders cache duration to 24 hours

### DIFF
--- a/src/utils/LockOverviewUtils.ts
+++ b/src/utils/LockOverviewUtils.ts
@@ -41,7 +41,9 @@ export const calculateAPR = (
 export const getNumberOfHiIQHolders = async () => {
   try {
     const TOP_HOLDER_COUNT = 7
-    const response = await fetch(IQ_TOKEN_HOLDER)
+    const response = await fetch(IQ_TOKEN_HOLDER, {
+      next: { revalidate: 86400 },
+    })
     const data = await response.json()
     const totalHoldersCount =
       data.pager?.holders?.total ?? data.token?.holdersCount ?? 0


### PR DESCRIPTION
# PR title goes here

_This PR sets the cache duration for hiIQ holders data to 24h_

## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/3288