### PR TITLE
🔨chore: bumps posthog-js package to v1.186

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "next-redux-wrapper": "^7.0.5",
     "next-seo": "^5.5.0",
     "nextjs-progressbar": "^0.0.14",
-    "posthog-js": "^1.155.0",
+    "posthog-js": "1.186.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-i18next": "^11.17.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4176,6 +4176,11 @@ core-js-compat@^3.30.1:
   dependencies:
     browserslist "^4.21.5"
 
+core-js@^3.38.1:
+  version "3.39.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.39.0.tgz#57f7647f4d2d030c32a72ea23a0555b2eaa30f83"
+  integrity sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==
+
 cosmiconfig@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
@@ -6738,14 +6743,15 @@ postcss@8.4.14:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-posthog-js@^1.155.0:
-  version "1.155.0"
-  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.155.0.tgz#e3c50f5152ccfd41945be4f2ea39668f4fd18cae"
-  integrity sha512-gxi72Qcp7Vnq6efe5gNxsq84zyEFd33NUmoLSgcbMPhxU30qgc89Aw/N2mRB4mGrD3Mq0rCnDJUzGFdN59nR0g==
+posthog-js@1.186.2:
+  version "1.186.2"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.186.2.tgz#c1c29a9d7aa38cfd706295aebe343b18d992cd1e"
+  integrity sha512-e2cYHnq+1UEN0N3okJMlKXkprC8JkZkoLPFqp/CjKOlBvAoz05WOW1ROJiRGPzPxc8CWZQIzGLoRbAP+C5Hsbw==
   dependencies:
+    core-js "^3.38.1"
     fflate "^0.4.8"
     preact "^10.19.3"
-    web-vitals "^4.0.1"
+    web-vitals "^4.2.0"
 
 preact@^10.12.0, preact@^10.5.9:
   version "10.15.1"
@@ -8155,10 +8161,10 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-web-vitals@^4.0.1:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-4.2.3.tgz#270c4baecfbc6ec6fc15da1989e465e5f9b94fb7"
-  integrity sha512-/CFAm1mNxSmOj6i0Co+iGFJ58OS4NRGVP+AWS/l509uIK5a1bSoIVaHz/ZumpHTfHSZBpgrJ+wjfpAOrTHok5Q==
+web-vitals@^4.2.0:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-4.2.4.tgz#1d20bc8590a37769bd0902b289550936069184b7"
+  integrity sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==
 
 web3-core-helpers@1.5.2:
   version "1.5.2"


### PR DESCRIPTION
## 🔨chore: bumps posthog-js package to v1.186

This PR updates ``posthog-js`` package to v1.186

Fixes 