### PR TITLE
chore: Lock Period Enhancement

### DIFF
--- a/src/components/client/StakePage.tsx
+++ b/src/components/client/StakePage.tsx
@@ -252,10 +252,10 @@ const StakePage = () => {
               </Tabs>
             </Flex>
             <LockedDetails
-              setOpenUnlockNotification={status =>
+              setOpenUnlockNotification={(status) =>
                 setOpenUnlockNotification(status)
               }
-              setOpenRewardCalculator={status =>
+              setOpenRewardCalculator={(status) =>
                 setOpenRewardCalculator(status)
               }
               loading={isProcessingUnlock}

--- a/src/components/client/StakePage.tsx
+++ b/src/components/client/StakePage.tsx
@@ -252,10 +252,10 @@ const StakePage = () => {
               </Tabs>
             </Flex>
             <LockedDetails
-              setOpenUnlockNotification={(status) =>
+              setOpenUnlockNotification={status =>
                 setOpenUnlockNotification(status)
               }
-              setOpenRewardCalculator={(status) =>
+              setOpenRewardCalculator={status =>
                 setOpenRewardCalculator(status)
               }
               loading={isProcessingUnlock}

--- a/src/components/elements/Slider/LockSlider.tsx
+++ b/src/components/elements/Slider/LockSlider.tsx
@@ -10,6 +10,7 @@ import {
   InputLeftAddon,
   InputRightAddon,
   Input,
+  Box,
 } from '@chakra-ui/react'
 import { useAccount } from 'wagmi'
 import { useLockOverview } from '@/hooks/useLockOverview'
@@ -26,32 +27,45 @@ const LockSlider = ({
   const { isConnected } = useAccount()
   const { getMaximumLockablePeriod } = useLockOverview()
   const [remainingLockablePeriod, setRemainingLockablePeriod] = useState(208)
-  const [lockPeriod, setLockPeriod] = useState(1)
   const { lockEndDate } = useLockEnd()
+  const [isMaxLockPeriodReached, setIsMaxLockPeriodReached] = useState(false)
+
+  const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24
+  const DAYS_PER_WEEK = 7
+  const MILLISECONDS_PER_WEEK = MILLISECONDS_PER_DAY * DAYS_PER_WEEK
+
+  const [lockPeriod, setLockPeriod] = useState(
+    lockEndDate ? Math.ceil(lockEndDate.getTime() / MILLISECONDS_PER_WEEK) : 1,
+  )
 
   const t = useTranslations('hiiq.stake.stakeIQ')
 
   useEffect(() => {
-    if (lockEndDate && typeof lockEndDate !== 'number') {
-      const fetchMaxLockPeriod = async () => {
+    const checkMaxLockPeriod = async () => {
+      if (lockEndDate) {
         const maxDate = await getMaximumLockablePeriod(lockEndDate)
         if (maxDate > 0) {
-          const weeks = Number(maxDate / 7)
-          if (weeks > 1) setRemainingLockablePeriod(Number(weeks.toFixed()))
-          else {
+          const weeks = Number(maxDate / DAYS_PER_WEEK)
+
+          if (weeks > 1) {
+            setRemainingLockablePeriod(Number(weeks.toFixed()))
+            if (lockEndDate.getTime() >= maxDate) {
+              setIsMaxLockPeriodReached(true)
+              setLockPeriod(Number(weeks.toFixed()))
+              updateLockend(weeks * DAYS_PER_WEEK, lockEndDate)
+            }
+          } else {
             setRemainingLockablePeriod(0)
             setLockPeriod(0)
           }
         } else setRemainingLockablePeriod(208)
       }
-      fetchMaxLockPeriod()
-    } else {
-      setRemainingLockablePeriod(208)
     }
+    checkMaxLockPeriod()
   }, [lockEndDate, getMaximumLockablePeriod])
 
   useEffect(() => {
-    const defaultLockPeriod = remainingLockablePeriod > 0 ? 7 : 0
+    const defaultLockPeriod = remainingLockablePeriod > 0 ? DAYS_PER_WEEK : 0
 
     if (lockEndDate) {
       updateLockend(defaultLockPeriod)
@@ -67,7 +81,7 @@ const LockSlider = ({
       const convertedValue = typeof value === 'string' ? parseInt(value) : value
       if (convertedValue <= remainingLockablePeriod) {
         setLockPeriod(convertedValue)
-        updateLockend(convertedValue * 7, lockEndDate)
+        updateLockend(convertedValue * DAYS_PER_WEEK, lockEndDate)
       } else {
         let msg = ''
         if (remainingLockablePeriod > 0)
@@ -80,6 +94,27 @@ const LockSlider = ({
 
   return (
     <Flex direction="column" w="full" gap="3">
+      {isMaxLockPeriodReached && (
+        <Flex
+          direction="column"
+          w="full"
+          gap="3"
+          p="5"
+          rounded="lg"
+          border="solid 1px"
+          borderColor="green.500"
+          bg="green.50"
+        >
+          <Box>
+            <Text color="green.700" fontWeight="bold">
+              Maximum Lock Period Reached
+            </Text>
+            <Text color="green.600" fontSize="sm">
+              Your stake is locked for the maximum allowed period.
+            </Text>
+          </Box>
+        </Flex>
+      )}
       <Flex
         direction={{ base: 'column', md: 'row' }}
         p="5"
@@ -97,9 +132,10 @@ const LockSlider = ({
             w={{ base: 'full', md: 330, lg: 250 }}
             defaultValue={[lockPeriod]}
             value={[lockPeriod]}
-            onChange={(value) => updateLockPeriod(value[0])}
+            onChange={value => updateLockPeriod(value[0])}
             step={1}
             max={remainingLockablePeriod}
+            isDisabled={isMaxLockPeriodReached}
           >
             <RangeSliderTrack bg="divider2">
               <RangeSliderFilledTrack />
@@ -120,7 +156,7 @@ const LockSlider = ({
             <Input
               value={lockPeriod}
               w={{ base: 'full', md: '10' }}
-              onChange={(e) => updateLockPeriod(e.target.value)}
+              onChange={e => updateLockPeriod(e.target.value)}
               color="grayText4"
               disabled={!isConnected}
               bg="lightCard"

--- a/src/components/elements/Slider/LockSlider.tsx
+++ b/src/components/elements/Slider/LockSlider.tsx
@@ -132,7 +132,7 @@ const LockSlider = ({
             w={{ base: 'full', md: 330, lg: 250 }}
             defaultValue={[lockPeriod]}
             value={[lockPeriod]}
-            onChange={value => updateLockPeriod(value[0])}
+            onChange={(value) => updateLockPeriod(value[0])}
             step={1}
             max={remainingLockablePeriod}
             isDisabled={isMaxLockPeriodReached}
@@ -156,7 +156,7 @@ const LockSlider = ({
             <Input
               value={lockPeriod}
               w={{ base: 'full', md: '10' }}
-              onChange={e => updateLockPeriod(e.target.value)}
+              onChange={(e) => updateLockPeriod(e.target.value)}
               color="grayText4"
               disabled={!isConnected}
               bg="lightCard"

--- a/src/components/lock/StakeIQ.tsx
+++ b/src/components/lock/StakeIQ.tsx
@@ -252,7 +252,7 @@ const StakeIQ = ({ exchangeRate }: { exchangeRate: number }) => {
         <Flex align="center" gap="2.5" w="full">
           <Input
             variant="unstyled"
-            onChange={e => updateIqToBeLocked(e.target.value)}
+            onChange={(e) => updateIqToBeLocked(e.target.value)}
             placeholder="23.00"
             value={userInput}
             color="fadedText4"
@@ -278,7 +278,7 @@ const StakeIQ = ({ exchangeRate }: { exchangeRate: number }) => {
         </Flex>
       </VStack>
       {userTotalIQLocked < 1 && (
-        <LockSlider updateLockend={newDate => updateLockend(newDate)} />
+        <LockSlider updateLockend={(newDate) => updateLockend(newDate)} />
       )}
       <IconButton
         icon={<RiArrowDownLine />}

--- a/src/components/lock/StakeIQ.tsx
+++ b/src/components/lock/StakeIQ.tsx
@@ -28,6 +28,7 @@ const StakeIQ = ({ exchangeRate }: { exchangeRate: number }) => {
   const [loading, setLoading] = useState(false)
   const { showToast } = useReusableToast()
   const { userTokenBalance } = useErc20()
+  console.log('userTokenBalance', userTokenBalance)
   const { lockIQ, increaseLockAmount } = useLock()
   const { userTotalIQLocked, refreshTotalIQLocked, refetchUserLockEndDate } =
     useLockOverview()
@@ -251,7 +252,7 @@ const StakeIQ = ({ exchangeRate }: { exchangeRate: number }) => {
         <Flex align="center" gap="2.5" w="full">
           <Input
             variant="unstyled"
-            onChange={(e) => updateIqToBeLocked(e.target.value)}
+            onChange={e => updateIqToBeLocked(e.target.value)}
             placeholder="23.00"
             value={userInput}
             color="fadedText4"
@@ -277,7 +278,7 @@ const StakeIQ = ({ exchangeRate }: { exchangeRate: number }) => {
         </Flex>
       </VStack>
       {userTotalIQLocked < 1 && (
-        <LockSlider updateLockend={(newDate) => updateLockend(newDate)} />
+        <LockSlider updateLockend={newDate => updateLockend(newDate)} />
       )}
       <IconButton
         icon={<RiArrowDownLine />}

--- a/src/components/wallet/use-fetch-wallet-balance.ts
+++ b/src/components/wallet/use-fetch-wallet-balance.ts
@@ -51,6 +51,7 @@ export const useFetchWalletBalance = (addressOrName: string | undefined) => {
         },
       }
       const result = [convertedIqData, convertedErc20Data]
+
       setUserBalance(result)
       isFeteched.current = true
     }

--- a/src/hooks/useLockOverview.ts
+++ b/src/hooks/useLockOverview.ts
@@ -78,6 +78,7 @@ export const useLockOverview = (userAddress?: string) => {
     const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
     return diffDays - 1
   }
+
   return {
     totalHiiq,
     totalLockedIq,


### PR DESCRIPTION
# chore: Lock Period Enhancement

## Changes Made
- Updated the initial lock period value to reflect the maximum period when max is reached
- Set the current period as the initial value for the lock period slider
- Added visual feedback when maximum lock period is reached via a green notification banner
- Improved UX by automatically setting appropriate initial values based on lock status
